### PR TITLE
stage7: Add kernel build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM i386/debian:buster
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -y update && \
     apt-get -y install \
-        git vim parted \
-        quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
-        bsdtar libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc\
-    && rm -rf /var/lib/apt/lists/*
+	git vim parted \
+	quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
+	bsdtar libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc \
+	bison flex libssl-dev  build-essential libgtk-3-dev gcc-arm-linux-gnueabihf \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY . /pi-gen/
 

--- a/depends
+++ b/depends
@@ -17,3 +17,6 @@ file
 git
 lsmod:kmod
 bc
+bison
+flex
+libssl

--- a/depends
+++ b/depends
@@ -19,4 +19,3 @@ lsmod:kmod
 bc
 bison
 flex
-libssl

--- a/stage7/00-console-autologin/00-run.sh
+++ b/stage7/00-console-autologin/00-run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+on_chroot << EOF
+	SUDO_USER="${FIRST_USER_NAME}" raspi-config nonint do_boot_behaviour B4
+EOF

--- a/stage7/01-adi-kernel-dts/00-run.sh
+++ b/stage7/01-adi-kernel-dts/00-run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+DEFCONFIG_PI0=adi_bcmrpi_defconfig
+DEFCONFIG_PI3=adi_bcm2709_defconfig
+DEFCONFIG_PI4=adi_bcm2711_defconfig
+KERNEL_IMG_PI0=kernel.img
+KERNEL_IMG_PI3=kernel7.img
+KERNEL_IMG_PI4=kernel7l.img
+SCRIPTS_DIR=wiki-scripts
+LINUX_DIR="${1:-linux-adi}"
+
+build_linux() {
+
+	pushd "$WORK_DIR"
+
+	[ -d "$SCRIPTS_DIR" ] || {
+		git clone https://github.com/analogdevicesinc/wiki-scripts.git "$SCRIPTS_DIR"
+	}
+	export DEFCONFIG=$1
+	source $SCRIPTS_DIR/linux/build_rpi_kernel_image.sh $LINUX_DIR "" "arm-linux-gnueabihf-"
+	cp -f zImage $STAGE_WORK_DIR/rootfs/boot/$2
+
+	pushd "$LINUX_DIR"
+	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=$STAGE_WORK_DIR/rootfs modules_install
+	make dtbs
+
+	popd 1> /dev/null
+	popd 1> /dev/null
+}
+
+build_linux $DEFCONFIG_PI0 $KERNEL_IMG_PI0
+build_linux $DEFCONFIG_PI3 $KERNEL_IMG_PI3
+build_linux $DEFCONFIG_PI4 $KERNEL_IMG_PI4
+
+cp -f $WORK_DIR/$LINUX_DIR/arch/$ARCH/boot/dts/overlays/*.dtb* $STAGE_WORK_DIR/rootfs/boot/overlays
+
+echo "Kernel build finished."
+

--- a/stage7/EXPORT_IMAGE
+++ b/stage7/EXPORT_IMAGE
@@ -1,0 +1,4 @@
+IMG_SUFFIX="-full"
+if [ "${USE_QEMU}" = "1" ]; then
+	export IMG_SUFFIX="${IMG_SUFFIX}-qemu"
+fi

--- a/stage7/EXPORT_NOOBS
+++ b/stage7/EXPORT_NOOBS
@@ -1,0 +1,2 @@
+NOOBS_NAME="Raspbian"
+NOOBS_DESCRIPTION="A port of Debian with the Raspberry Pi Desktop"

--- a/stage7/prerun.sh
+++ b/stage7/prerun.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+if [ ! -d "${ROOTFS_DIR}" ]; then
+	copy_previous
+fi


### PR DESCRIPTION
This patch adds a separate stage for kernel build. This will clone the
linux-adi repository and build the kernel, dts and modules for raspberry
pi.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>