### PR TITLE
stage3: install-packages: Install GTK3 package

### DIFF
--- a/stage3/00-install-packages/00-packages
+++ b/stage3/00-install-packages/00-packages
@@ -13,3 +13,4 @@ fonts-droid-fallback
 fonts-liberation2
 obconf
 arandr
+libgtk-3-dev


### PR DESCRIPTION
This packages is required by the jesd_status/eyescan application.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>