### PR TITLE
stage6: gr-iio: Fix install prefix for gr-iio

### DIFF
--- a/stage6/03-gr-iio/00-run.sh
+++ b/stage6/03-gr-iio/00-run.sh
@@ -4,7 +4,7 @@ on_chroot << EOF
 
 git clone https://github.com/analogdevicesinc/gr-iio.git
 pushd gr-iio
-cmake .
+cmake -DCMAKE_INSTALL_PREFIX=/usr .
 make -j $NUM_JOBS
 sudo make install
 popd


### PR DESCRIPTION
This patch will set the install prefix for cmake configuration to /usr.

Fixes: 879b8c03e386 ("stage6: Add gr-iio to the build")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>