### PR TITLE
Revert "stage2: sys-tweaks: Remove iiod service file"

### DIFF
--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -11,6 +11,7 @@ install -m 644 files/console-setup   	"${ROOTFS_DIR}/etc/default/"
 
 install -m 755 files/rc.local		"${ROOTFS_DIR}/etc/"
 
+install -m 644 files/iiod.service	"${ROOTFS_DIR}/lib/systemd/system/"
 install -m 644 files/x11vnc.service	"${ROOTFS_DIR}/lib/systemd/system/"
 
 install -d				"${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.vnc"
@@ -30,6 +31,7 @@ else
 	systemctl disable ssh
 fi
 systemctl enable regenerate_ssh_host_keys
+systemctl enable iiod
 systemctl enable x11vnc
 EOF
 


### PR DESCRIPTION
Will investigate more when USBD will be added with a watcher for changes to the usb_gadget folder. It seems that iiod service is installed but not enabled so this is required for iiod to be running at startup.