### PR TITLE
stage6: Add 2019_R2 option to adi_update_tools

### DIFF
--- a/stage6/02-adi-update-tools/00-run.sh
+++ b/stage6/02-adi-update-tools/00-run.sh
@@ -5,9 +5,8 @@ git clone https://github.com/analogdevicesinc/linux_image_ADI-scripts
 
 pushd linux_image_ADI-scripts
 chmod +x adi_update_tools.sh
-./adi_update_tools.sh
+./adi_update_tools.sh 2019_R2
 
 popd
 
-rm -rf linux_image_ADI-scripts
 EOF


### PR DESCRIPTION
To have a stable set of applications this build has been shifted to the
release branch 2019_R2. Also the linux_image_ADI_scripts will not be
removed to have them available for future use.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>