### PR TITLE
stage6: packages: Add libusb-1.0

### DIFF
--- a/stage6/01-install-packages/00-packages
+++ b/stage6/01-install-packages/00-packages
@@ -71,3 +71,4 @@ locate
 libzmq3-dev
 gnuplot
 xterm
+libusb-1.0


### PR DESCRIPTION
This packages is used to enable libiio usb banckend.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>