### PR TITLE
stage8: extra-boot: Extend folder level

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -185,6 +185,7 @@ export CLEAN
 export IMG_NAME
 export APT_PROXY
 export EXTRA_BOOT
+export EXTRA_BOOT_DIR_DEPTH="${EXTRA_BOOT_DIR_DEPTH:-3}"
 
 export STAGE
 export STAGE_DIR

--- a/stage8/02-extra-boot/00-run.sh
+++ b/stage8/02-extra-boot/00-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
 if [ -n ${EXTRA_BOOT} ]; then
-	wget -r -nH --cut-dirs=4 -np -R "index.html*" -l2 "${EXTRA_BOOT}" -P "${STAGE_WORK_DIR}/rootfs/boot"
+	wget -r -nH --cut-dirs=4 -np -R "index.html*" "-l${EXTRA_BOOT_DIR_DEPTH}" "${EXTRA_BOOT}" -P "${STAGE_WORK_DIR}/rootfs/boot"
 fi


### PR DESCRIPTION
Extend folder level to l3 to be able to wget all the necessary files.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>