### PR TITLE
stage6: libm2k: Add udev rules to cmake

### DIFF
--- a/stage6/04-gnuradio-m2k/00-run.sh
+++ b/stage6/04-gnuradio-m2k/00-run.sh
@@ -69,7 +69,7 @@ build_libm2k() {
 		-DENABLE_CSHARP=OFF\
 		-DENABLE_EXAMPLES=ON\
 		-DENABLE_TOOLS=ON\
-		-DINSTALL_UDEV_RULES=OFF ../
+		-DINSTALL_UDEV_RULES=ON ../
 
 	make $JOBS
 	make ${JOBS} install


### PR DESCRIPTION
Before this patch udev rules where not installed for libm2k this was
causing m2k board to not be visible inside scopy. This removes the cmake
option to not install udev rules.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>