### PR TITLE
stage6: hptdate: Add htpdate package

### DIFF
--- a/stage6/01-install-packages/00-packages
+++ b/stage6/01-install-packages/00-packages
@@ -72,3 +72,4 @@ libzmq3-dev
 gnuplot
 xterm
 libusb-1.0
+htpdate


### PR DESCRIPTION
Thsi is used to get correct time and date from an external server.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>