### PR TITLE
stage4: Add ttyPS0 to securetty

### DIFF
--- a/stage4/01-console-autologin/00-run.sh
+++ b/stage4/01-console-autologin/00-run.sh
@@ -9,4 +9,6 @@ on_chroot << EOF
 	systemctl enable serial-getty@ttyS0.service
 	sed -i '1s/^/auth sufficient pam_listfile.so item=tty sense=allow file=\/etc\/securetty onerr=fail apply=root\n/' "/etc/pam.d/login"
 
+	echo "ttyPS0" >> /etc/securetty
+
 EOF


### PR DESCRIPTION
For ZynqMP platforms the ttyPS0 interface is used for serial communication.
In order for automatic root login on ttyPS0 to work it must be include in
/etc/securetty.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>