### PR TITLE
stage6: Add eepromutils

### DIFF
--- a/stage6/08-eepromutil/00-run.sh
+++ b/stage6/08-eepromutil/00-run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+on_chroot << EOF
+
+mkdir -p "home/${FIRST_USER_NAME}"
+pushd "home/${FIRST_USER_NAME}"
+
+[ -d "hats" ] || {
+    git clone https://github.com/raspberrypi/hats.git -b "master"
+}
+
+pushd hats
+pushd eepromutils
+
+make && sudo make install
+
+popd 1> /dev/null # pushd eepromutils
+popd 1> /dev/null # pushd hats
+popd 1> /dev/null # pushd home/analog
+
+rm -rf hats/
+
+EOF


### PR DESCRIPTION
These utilities are used to create, flash and dump HAT EEPROM images.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>