### PR TITLE
Revert "stage8: Only generate full image"

### DIFF
--- a/stage8/EXPORT_NOOBS
+++ b/stage8/EXPORT_NOOBS
@@ -1,0 +1,2 @@
+NOOBS_NAME="Raspbian"
+NOOBS_DESCRIPTION="A port of Debian with the Raspberry Pi Desktop"


### PR DESCRIPTION
This reverts commit dbd9497f7ed907452f7caa63d9249e7bfc3c127a.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>