### PR TITLE
stage8: Fix license generation

### DIFF
--- a/stage8/00-license-generation/00-run.sh
+++ b/stage8/00-license-generation/00-run.sh
@@ -214,13 +214,31 @@ html_header "${TARGET} Legal Information"
 
 html_h1 "Legal Information"
 
-convert_md2html LICENSE >> ${FILE}
+convert_md2html LICENSE.md >> ${FILE}
 
 echo "<div class=\"boxed\">" >> ${FILE}
 html_h2 "Written Offer"
 
 echo "<p>As described above, the Image included in the ${TARGET} contains copyrighted software that is released and distributed under many licenses, including the GPL.
 A copy of the licenses are included in this file (below)." >> ${FILE}
+
+echo "You may obtain the complete Corresponding Source code from us for a period of three years after our last shipment of this product, which will be no earlier than " >> ${FILE}
+date --date="3 years 6 months" +"%d%b%Y" >> ${FILE}
+echo ", by sending a money order or check for \$15 (USD) to:</p>
+<pre>
+Analog Devices Inc.
+Systems Development Group
+GPL Compliance
+Attention: Robin Getz
+1 Analog Way
+Wilmington, Massachusetts
+01887
+USA
+</pre>
+<p>Please write “<i>source for the ${TARGET}</i>” in the memo line of your payment.
+Since the source does not fit on a DVD-RW, it will be delivered on a USB Thumb drive (hense the higher cost than just DVD or CD).</p>
+<p><b>You will also find a the source on-line, and are encouraged to obtain it for zero cost, at the project web sites.</b></p>
+</div>" >> ${FILE}
 
 html_h2 "NO WARRANTY"
 
@@ -243,7 +261,7 @@ echo "<th>Location</th>" >> ${FILE}
 echo "</tr>" >> ${FILE}
 echo "</thead>" >> ${FILE}
 echo "<tbody>" >> ${FILE}
-package_table_items $((var++)) Linux "4.19" "GPLv2" "https://github.com/analogdevicesinc/linux"
+package_table_items $((var++)) Linux "5.4" "GPLv2" "https://github.com/analogdevicesinc/linux"
 
 dpkg -l | awk '/ii/ { print $2 " " $3 }' | while read -r line
 do

--- a/stage8/00-license-generation/LICENSE.md
+++ b/stage8/00-license-generation/LICENSE.md
@@ -1,5 +1,5 @@
 # Analog Device Kuiper Linux
-Analog Device Kuiper Linux [ADI-Kuiper](https://wiki.analog.com/resources/tools-software/linux-software/adi-kuiper_images "ADI-Kuiper Wiki Page")
+Analog Devices Kuiper Linux [ADI-Kuiper](https://wiki.analog.com/resources/tools-software/linux-software/adi-kuiper_images "ADI-Kuiper Wiki Page")
 
 The Analog Devices Kuiper Linux is an [aggregation](https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.en.html#MereAggregation "GPL FAQ") of components, computer programs and documents which communicate thought standard kernel/userspace ABIs, pipes, sockets and command-line arguments.
 These separate and unique programs are created by a range of individuals, teams and companies.


### PR DESCRIPTION
This patch renames the License.md file to match the one requested in the
script - LICENSE.md. Also the "Written Offer" section was added.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>