### PR TITLE
stage6: aditof-sdk: Fix process using 100% of cpu core

### DIFF
--- a/stage6/07-aditof-sdk/00-run.sh
+++ b/stage6/07-aditof-sdk/00-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-ADITOF_SDK_BRANCH=v2.0.0 # this branch will be bumped for new releases
+ADITOF_SDK_BRANCH=v2.0.0-busy-server-fix # this branch will be bumped for new releases
 
 on_chroot << EOF
 


### PR DESCRIPTION
ADITOF-SDK was using one core of the controller at 100% all the time. This
patch changes the tag used for building the software for ADI Kuiper to use
the fixed version.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>