### PR TITLE
export_image: comment 'update' and 'dist-upgrade' commands and print extra logs

### DIFF
--- a/export-image/01-set-sources/01-run.sh
+++ b/export-image/01-set-sources/01-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 on_chroot << EOF
-apt-get update
-apt-get -y dist-upgrade
+#apt-get update
+#apt-get -y dist-upgrade
 apt-get clean
 EOF


### PR DESCRIPTION
Comment 'apt-get update' and 'apt-get dist-upgrade' in export_image since the same commands are also run in first stages.