### PR TITLE
stage2/01-sys-tweaks: disable RPI bootfiles update

### DIFF
--- a/stage2/01-sys-tweaks/00-packages
+++ b/stage2/01-sys-tweaks/00-packages
@@ -17,7 +17,6 @@ pi-bluetooth
 apt-listchanges
 usb-modeswitch
 libpam-chksshpwd
-rpi-update
 libmtp-runtime
 rsync
 htop

--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -72,4 +72,13 @@ on_chroot << EOF
 setupcon --force --save-only -v
 EOF
 
+on_chroot << EOF
+#mark on hold packages that update boot files, modules, firmware, eeprom etc
+sudo apt-mark hold libraspberrypi-bin libraspberrypi-dev libraspberrypi-doc libraspberrypi0
+sudo apt-mark hold raspberrypi-bootloader raspberrypi-kernel raspberrypi-kernel-headers
+
+#disable automatic update of eeprom
+systemctl mask rpi-eeprom-update
+EOF
+
 rm -f "${ROOTFS_DIR}/etc/ssh/"ssh_host_*_key*


### PR DESCRIPTION
'rpi-update' package is installed by default on pi-gen and can be used to
upgrade bootfiles and firmware. This is the old method that, from some reasons,
was kept on pi-gen. New method uses packages 'raspberrypi-bootloader' and
'raspberrypi-kernel' with their dependencies to do the same things. They are
upgradable by "apt-get update/upgrade" command.
RPI4 don't use /boot/bootcode.bin but uses eeprom instead. File on eeprom can be
updated using 'rpi-eeprom' package. By default rpi-eeprom-update service runs at
startup and prompts for applying new updates if there are.

https://raspberrypi.stackexchange.com/questions/4355/do-i-still-need-rpi-update-if-i-am-using-the-latest-version-of-raspbian
https://forums.raspberrypi.com/viewtopic.php?t=281519#p1705079
https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#automaticupdates

Signed-off-by: stefan.raus <stefan.raus@analog.com>