### PR TITLE
stage8: extra_boot: Fix envvar

### DIFF
--- a/stage8/02-extra-boot/00-run.sh
+++ b/stage8/02-extra-boot/00-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-if [ -n ${EXTRA_BOOT} ]; then
+if [[ ! -z ${EXTRA_BOOT} ]]; then
 	wget -r -q --show-progress -nH --cut-dirs=5 -np -R "index.html*" "-l inf" "${EXTRA_BOOT}" -P "${STAGE_WORK_DIR}/rootfs/boot"
 else
 	rm -f latest_boot_partition.tar.gz


### PR DESCRIPTION
This change prevents the build from failing if EXTRA_BOOT is
missing.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>