### PR TITLE
stage6: Add dummy xorg package

### DIFF
--- a/stage6/01-install-packages/00-packages
+++ b/stage6/01-install-packages/00-packages
@@ -85,3 +85,4 @@ vim
 dialog
 ckermit
 software-properties-common
+xserver-xorg-video-dummy


### PR DESCRIPTION
Add dummy xorg package for boards without any video ports.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>