### PR TITLE
stage6:03-pyadi: Fix typo in PYTHONPATH

### DIFF
--- a/stage6/03-pyadi/00-run.sh
+++ b/stage6/03-pyadi/00-run.sh
@@ -4,7 +4,7 @@ on_chroot << EOF
 
 pip3 install pyadi-iio
 pip3 install git+https://github.com/analogdevicesinc/pyadi-dt.git
-echo "export PYTHONPATH=\"${PYTHONPATH}:/usr/local/lib/python3/dist-package:/lib/python3.9/site-packages\"" >> /home/analog/.bashrc
+echo "export PYTHONPATH=\"${PYTHONPATH}:/usr/local/lib/python3/dist-packages:/lib/python3.9/site-packages\"" >> /home/analog/.bashrc
 echo "export LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}:/usr/local/lib\"" >> /home/analog/.bashrc
 ldconfig
 EOF


### PR DESCRIPTION
Update PYTHONPATH var to point to proper python3 dist-packages path.

Signed-off-by: stefan.raus <stefan.raus@analog.com>