### PR TITLE
stage6:04-gnuradio-m2k: fix iio import in gnuradio

### DIFF
--- a/stage6/03-pyadi/00-run.sh
+++ b/stage6/03-pyadi/00-run.sh
@@ -4,7 +4,7 @@ on_chroot << EOF
 
 pip3 install pyadi-iio
 pip3 install git+https://github.com/analogdevicesinc/pyadi-dt.git
-echo "export PYTHONPATH=\"${PYTHONPATH}:/usr/local/lib/python3/dist-package:/lib/python3.9/site-packages\"" >> /home/analog/.bashrc
+echo "export PYTHONPATH=\"${PYTHONPATH}:/usr/local/lib/python3/dist-packages:/lib/python3.9/site-packages\"" >> /home/analog/.bashrc
 echo "export LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}:/usr/local/lib\"" >> /home/analog/.bashrc
 ldconfig
 EOF

--- a/stage6/04-gnuradio-m2k/00-run.sh
+++ b/stage6/04-gnuradio-m2k/00-run.sh
@@ -82,6 +82,10 @@ build_griio() {
 	popd 1> /dev/null
 
 	rm -rf gr-iio/
+
+	# Update gnu-radio-grc.desktop
+	sed -i 's/Exec=/Exec=env PYTHONPATH=\/usr\/local\/lib\/python3\/dist-packages:\/lib\/python3.9\/site-packages /g' "/usr/share/applications/gnuradio-grc.desktop"
+
 }
 
 build_grm2k() {
@@ -123,5 +127,5 @@ build_gnuradio
 build_libm2k
 build_griio
 build_grm2k
-
+ldconfig
 EOF


### PR DESCRIPTION
Update gnuradio-grc.desktop to open Gnu Radio from menu with parameter
"PYTHONPATH=usr/local/lib/python3/dist-packages:/lib/python3.9/site-packages"
This will load correct iio, gr-iio instead of ADI libiio.

Fix also a typo in PYTHONPATH variable from bashrc.

Signed-off-by: stefan.raus <stefan.raus@analog.com>