### PR TITLE
stage6/03: remove PYTHONPATH from .bashrc

### DIFF
--- a/stage6/03-pyadi/00-run.sh
+++ b/stage6/03-pyadi/00-run.sh
@@ -4,7 +4,6 @@ on_chroot << EOF
 
 pip3 install pyadi-iio
 pip3 install git+https://github.com/analogdevicesinc/pyadi-dt.git
-echo "export PYTHONPATH=\"${PYTHONPATH}:/usr/local/lib/python3/dist-packages:/lib/python3.9/site-packages\"" >> /home/analog/.bashrc
 echo "export LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}:/usr/local/lib\"" >> /home/analog/.bashrc
 ldconfig
 EOF


### PR DESCRIPTION
Do not set PYTHONPATH on /home/analog/.bashrc since this will broke 
loading libiio properly. In this way, python will look for libs only in default paths. 

On gnuradio side, gr-iio are loader properly when gnuradio is open from
Kuiper Menu (fixed with commit 1b52286).

Signed-off-by: stefan.raus <stefan.raus@analog.com>