### PR TITLE
00-packages: add libatlas-base-dev package

### DIFF
--- a/stage4/00-install-packages/00-packages
+++ b/stage4/00-install-packages/00-packages
@@ -23,3 +23,4 @@ piwiz
 rp-prefapps
 ffmpeg
 vlc
+libatlas-base-dev


### PR DESCRIPTION
GnuRadio Companion fails to open due to missing libcblas.so3 library.
I seems that this was added by libcblas-dev package which got changed
to libatlas-base-dev.

Signed-off-by: stefan.raus <stefan.raus@analog.com>