### PR TITLE
stage7:adi-kernel-dts: let default kernels and DTS

### DIFF
--- a/stage7/01-adi-kernel-dts/00-run.sh
+++ b/stage7/01-adi-kernel-dts/00-run.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-rm -rf ${STAGE_WORK_DIR}/rootfs/boot/kernel*.img ${STAGE_WORK_DIR}/rootfs/boot/bcm*.dtb ${STAGE_WORK_DIR}/rootfs/boot/overlays
-rm -rf ${STAGE_WORK_DIR}/rootfs/lib/modules/*
-
 if [[ ! -z ${RPI_BOOT} ]]; then
 	wget -r -q --show-progress -nH --cut-dirs=5 -np -R "index.html*" "-l inf" "${RPI_BOOT}" -P "${STAGE_WORK_DIR}/rootfs/boot"
 	tar -xvf "${STAGE_WORK_DIR}/rootfs/boot/rpi_modules.tar.gz" -C "${STAGE_WORK_DIR}/rootfs/lib/modules" --no-same-owner


### PR DESCRIPTION
Commit 335280fb ("stage7/01-adi-kernel: remove building RPI kernels") changed the script to download already built files (kernels, devicetrees, overlays and modules) instead of building them, decreasing in this way total build time of Kuiper. 

At that time, we decided to delete all default files (kernels, dts etc) but since we are not building everything, some RPI versions (like RPI Zero W , RPI Zero 2W) will not boot anymore since they don't have all necessary boot files.

Let all default boot files and only overwrite the ones built by ADI.

Signed-off-by: stefan.raus <stefan.raus@analog.com>