### PR TITLE
stage6: 04-gnuradio-m2k: switch gr-m2k to 'maint-3.8'

### DIFF
--- a/stage6/04-gnuradio-m2k/00-run.sh
+++ b/stage6/04-gnuradio-m2k/00-run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 LIBM2K_BRANCH=master
-GRIIO_BRANCH=upgrade-3.8
-GRM2K_BRANCH=master
+GRIIO_BRANCH="upgrade-3.8"
+GRM2K_BRANCH="maint-3.8"
 LIBSIGROKDECODE_BRANCH=master
 
 SCOPY_RELEASE="v1.4.0"


### PR DESCRIPTION
Change gr-m2k branch to be built from 'master' to 'maint-3.8', since this branch is still using GnuRadio 3.8. Master branch got updated to 3.10 GnuRadio version.

Signed-off-by: stefan.raus <stefan.raus@analog.com>