### PR TITLE
Update license

### DIFF
--- a/stage5/01-ldconfig/00-run.sh
+++ b/stage5/01-ldconfig/00-run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+on_chroot << EOF
+ldconfig
+EOF

--- a/stage8/00-license-generation/00-run.sh
+++ b/stage8/00-license-generation/00-run.sh
@@ -228,18 +228,16 @@ echo "You may obtain the complete Corresponding Source code from us for a period
 date --date="3 years 6 months" +"%d%b%Y" >> ${FILE}
 echo ", by sending a money order or check for \$15 (USD) to:</p>
 <pre>
-Analog Devices Inc.
-Systems Development Group
-GPL Compliance
-Attention: Robin Getz
-1 Analog Way
-Wilmington, Massachusetts
-01887
-USA
+Director, Open Source Program Office
+Analog Devices
+Citypoint
+65 Haymarket Terrace
+Edinburgh EH5 3PN
+United Kingdom
 </pre>
 <p>Please write “<i>source for the ${TARGET}</i>” in the memo line of your payment.
-Since the source does not fit on a DVD-RW, it will be delivered on a USB Thumb drive (hense the higher cost than just DVD or CD).</p>
-<p><b>You will also find a the source on-line, and are encouraged to obtain it for zero cost, at the project web sites.</b></p>
+Since the source does not fit on a DVD-RW, it will be delivered on a USB Thumb drive (hence the higher cost than just DVD or CD).</p>
+<p><b>You will also find the source on-line, and are encouraged to obtain it for zero cost, at the project web sites.</b></p>
 </div>" >> ${FILE}
 
 html_h2 "NO WARRANTY"

--- a/stage8/00-license-generation/00-run.sh
+++ b/stage8/00-license-generation/00-run.sh
@@ -261,7 +261,15 @@ echo "<th>Location</th>" >> ${FILE}
 echo "</tr>" >> ${FILE}
 echo "</thead>" >> ${FILE}
 echo "<tbody>" >> ${FILE}
-package_table_items $((var++)) Linux "5.4" "GPLv2" "https://github.com/analogdevicesinc/linux"
+package_table_items $((var++)) "Linux" "5.10" "GPLv2" "https://github.com/analogdevicesinc/linux"
+package_table_items $((var++)) "HDL"   " "    "GPL/LGPL/BSD" "https://github.com/analogdevicesinc/hdl"
+package_table_items $((var++)) "HDL Testbenches" " " "GPL" "https://github.com/analogdevicesinc/testbenches"
+package_table_items $((var++)) "LibIIO" " " "LGPL-2.1/GPL-2.0" "https://github.com/analogdevicesinc/libiio"
+package_table_items $((var++)) "IIO Oscilloscope" " " "GPL-2.0" "https://github.com/analogdevicesinc/iio-oscilloscope"
+package_table_items $((var++)) "Scopy" " " "GPL-3.0" "https://github.com/analogdevicesinc/scopy"
+package_table_items $((var++)) "libad9361-iio" " " "GPL-2.0" "https://github.com/analogdevicesinc/libad9361-iio"
+package_table_items $((var++)) "libad9166-iio" " " "GPL-2.0" "https://github.com/analogdevicesinc/libad9166-iio"
+package_table_items $((var++)) "fru-tools" " " "GPL-2.0" "https://github.com/analogdevicesinc/fru-tools"
 
 dpkg -l | awk '/ii/ { print $2 " " $3 }' | while read -r line
 do


### PR DESCRIPTION
1. Add 'ldconfig' command after installing all packages from stage5 otherwise stage6/01-install-packages step will fail on build
because it wont find /lib/ld-linux-armhf.so.3 library.
2. Update "Written Offer" surface-mail address to point to the OSPO and fix typos.
3. Add ADI components in /home/analog/LICENCE.html file.