### PR TITLE
Install jupyter and python3-matplotlib

### DIFF
--- a/stage6/01-install-packages/00-packages
+++ b/stage6/01-install-packages/00-packages
@@ -11,6 +11,8 @@ swig
 g++
 libboost-all-dev
 libgmp-dev
+jupyter
+python3-matplotlib
 python3-numpy
 python3-mako
 python3-sphinx


### PR DESCRIPTION
These packages are required for a full installation of Jupyter Notebook.

Signed-off-by: Raluca Groza <raluca.groza@analog.com>