### PR TITLE
Delete only .dtbo files - 2021_R2

### DIFF
--- a/stage7/01-adi-kernel-dts/00-run.sh
+++ b/stage7/01-adi-kernel-dts/00-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-rm -rf ${STAGE_WORK_DIR}/rootfs/boot/kernel*.img ${STAGE_WORK_DIR}/rootfs/boot/bcm*.dtb ${STAGE_WORK_DIR}/rootfs/boot/overlays
+rm -rf ${STAGE_WORK_DIR}/rootfs/boot/kernel*.img ${STAGE_WORK_DIR}/rootfs/boot/bcm*.dtb ${STAGE_WORK_DIR}/rootfs/boot/overlays/*.dtbo
 rm -rf ${STAGE_WORK_DIR}/rootfs/lib/modules/*
 
 if [[ ! -z ${RPI_BOOT} ]]; then


### PR DESCRIPTION
With this change only the .dtbo files will be removed so README file will stay available for overlays.
Signed-off-by: Raluca Chis <raluca.chis@analog.com>