### PR TITLE
stage6: add libopenblas-dev package to next_stable

### DIFF
--- a/stage6/01-install-packages/00-packages
+++ b/stage6/01-install-packages/00-packages
@@ -82,6 +82,7 @@ xterm
 libusb-1.0
 htpdate
 libopencv-dev
+libopenblas-dev
 vim
 dialog
 ckermit


### PR DESCRIPTION
## Pull Request Description

Install libopenblas-dev since it is a dependency for the newer version of RPI Sense HAT emulator.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
