### PR TITLE
Bring changes from 2022_R2 branch back to main

### DIFF
--- a/stage6/01-install-packages/00-packages
+++ b/stage6/01-install-packages/00-packages
@@ -82,6 +82,7 @@ xterm
 libusb-1.0
 htpdate
 libopencv-dev
+libopenblas-dev
 vim
 dialog
 ckermit

--- a/stage6/02-adi-update-tools/00-run.sh
+++ b/stage6/02-adi-update-tools/00-run.sh
@@ -9,10 +9,11 @@ on_chroot << EOF
 
 
 [ -d "linux_image_ADI-scripts" ] || {
-	git clone https://github.com/analogdevicesinc/linux_image_ADI-scripts
+	git clone https://github.com/analogdevicesinc/linux_image_ADI-scripts -b main
 }
 
 pushd linux_image_ADI-scripts
+git checkout main
 chmod +x adi_update_tools.sh
 ./adi_update_tools.sh dev
 


### PR DESCRIPTION
## Pull Request Description

There is package "libopenblas-dev" added  to fix GnuRadio and RPI Sense Emulator.
And switching the default branch of linux_image_ADI-scripts repos, so adi_update_tools.sh. 
In this repo, we'll still need to keep also 'master' in parallel with main, since old versions of the script (updates from older Kuiper images) will look for it.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
