### PR TITLE
Fix databox

### DIFF
--- a/stage6/02-adi-update-tools/00-run.sh
+++ b/stage6/02-adi-update-tools/00-run.sh
@@ -6,7 +6,7 @@ on_chroot << EOF
    cd gtkdatabox-1.0.0
    ./configure
    make install
-
+   rm -rf gtkdatabox-1.0.0.tar.gz
 
    [ -d "linux_image_ADI-scripts" ] || {
 	git clone https://github.com/analogdevicesinc/linux_image_ADI-scripts -b main

--- a/stage6/02-adi-update-tools/00-run.sh
+++ b/stage6/02-adi-update-tools/00-run.sh
@@ -8,15 +8,15 @@ on_chroot << EOF
    make install
 
 
-[ -d "linux_image_ADI-scripts" ] || {
+   [ -d "linux_image_ADI-scripts" ] || {
 	git clone https://github.com/analogdevicesinc/linux_image_ADI-scripts -b main
-}
+   }
 
-pushd linux_image_ADI-scripts
-git checkout main
-chmod +x adi_update_tools.sh
-./adi_update_tools.sh dev
+   pushd linux_image_ADI-scripts
+   git checkout main
+   chmod +x adi_update_tools.sh
+   ./adi_update_tools.sh dev
 
-popd
+   popd
 
 EOF


### PR DESCRIPTION
## Pull Request Description

Remove gtkdatabox-1.0.0.tar.gz after is unpacked and installed because every time there is ran adi_update_tools.sh a new copy will be downloaded with a number appended at the end (ex. gtkdatabox-1.0.0.tar.gz.2). Fix also indentation.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
