### PR TITLE
2022 r2 fixes

### DIFF
--- a/stage6/02-adi-update-tools/00-run.sh
+++ b/stage6/02-adi-update-tools/00-run.sh
@@ -3,10 +3,13 @@
 on_chroot << EOF
    wget https://downloads.sourceforge.net/project/gtkdatabox/gtkdatabox-1/gtkdatabox-1.0.0.tar.gz
    tar xvf gtkdatabox-1.0.0.tar.gz
-   cd gtkdatabox-1.0.0
+
+   pushd gtkdatabox-1.0.0
    ./configure
    make install
+   popd
 
+   rm -rf gtkdatabox-1.0.0.tar.gz
 
 [ -d "linux_image_ADI-scripts" ] || {
 	git clone https://github.com/analogdevicesinc/linux_image_ADI-scripts -b main

--- a/stage6/02-adi-update-tools/00-run.sh
+++ b/stage6/02-adi-update-tools/00-run.sh
@@ -11,15 +11,13 @@ on_chroot << EOF
 
    rm -rf gtkdatabox-1.0.0.tar.gz
 
-[ -d "linux_image_ADI-scripts" ] || {
+   [ -d "linux_image_ADI-scripts" ] || {
 	git clone https://github.com/analogdevicesinc/linux_image_ADI-scripts -b main
-}
+   }
 
-pushd linux_image_ADI-scripts
-git checkout main
-chmod +x adi_update_tools.sh
-./adi_update_tools.sh 2022_R2
-
-popd
+   pushd linux_image_ADI-scripts
+   chmod +x adi_update_tools.sh
+   ./adi_update_tools.sh 2022_R2
+   popd
 
 EOF

--- a/stage6/04-gnuradio-m2k/00-run.sh
+++ b/stage6/04-gnuradio-m2k/00-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-LIBM2K_BRANCH="next_stable"
+LIBM2K_BRANCH="v0.8.0"
 GRIIO_BRANCH="upgrade-3.8" # let this to 'upgrade-3.8' since GNU Radio is 3.8.2
 GRM2K_BRANCH="maint-3.8" # let this to 'maint-3.8' since GNU Radio installed in Kuiper is 3.8.2
 LIBSIGROKDECODE_BRANCH="master"


### PR DESCRIPTION
## Pull Request Description

Cherry-pick commits that got in main in the meanwhile and update libm2k to use v0.8.0 release tag instead of next_stable.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
