### PR TITLE
stage6/02-adi-update-tools: fix databox deletion

### DIFF
--- a/stage6/02-adi-update-tools/00-run.sh
+++ b/stage6/02-adi-update-tools/00-run.sh
@@ -3,9 +3,12 @@
 on_chroot << EOF
    wget https://downloads.sourceforge.net/project/gtkdatabox/gtkdatabox-1/gtkdatabox-1.0.0.tar.gz
    tar xvf gtkdatabox-1.0.0.tar.gz
-   cd gtkdatabox-1.0.0
+
+   pushd gtkdatabox-1.0.0
    ./configure
    make install
+   popd
+
    rm -rf gtkdatabox-1.0.0.tar.gz
 
    [ -d "linux_image_ADI-scripts" ] || {
@@ -16,7 +19,6 @@ on_chroot << EOF
    git checkout main
    chmod +x adi_update_tools.sh
    ./adi_update_tools.sh dev
-
    popd
 
 EOF


### PR DESCRIPTION
## Pull Request Description

The command 'rm -rf gtkdatabox-1.0.0.tar.gz' is run inside the folder gtkdatabox-1.0.0 and there is no archive to delete. 
cd one level up and call rm command only afterwards. Switch also from cd to pushd/popd.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
