### PR TITLE
stage6/04-gnuradio-m2k: switch libm2k to v0.8.0

### DIFF
--- a/stage6/04-gnuradio-m2k/00-run.sh
+++ b/stage6/04-gnuradio-m2k/00-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-LIBM2K_BRANCH=master
+LIBM2K_BRANCH="v0.8.0"
 GRIIO_BRANCH="upgrade-3.8"
 GRM2K_BRANCH="maint-3.8"
 LIBSIGROKDECODE_BRANCH=master


### PR DESCRIPTION
## Pull Request Description
There are some fixes that got into libm2k repo, so instead of using master branch(which actually got replaced with main), just use the latest release tag v0.8.0 which have been also tested.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
