### PR TITLE
Add option to prepare the boot partition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
         parted moreutils \
         coreutils qemu-user-static debootstrap zip dosfstools \
-        rsync grep xxd kmod bc udev \
+        rsync grep xxd kmod bc udev jq \
         build-essential gcc-arm-linux-gnueabihf \
         u-boot-tools gcc-aarch64-linux-gnu gnupg \
         binfmt-support ca-certificates qemu-utils fdisk \

--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ The following environment variables are supported:
 * `USE_ADI_REPO_CARRIERS_BOOT` (Default: y)
 
    Installs carriers boot files package from the ADI repository, corresponding to the configured release.
+
+* `ADI_EVAL_BOARD` (Default empty)
+
+   Configure the project the Kuiper image will run. Together with the variable `CARRIER` it can be used to prepare \
+   the boot partition during build time with the required ADI project and carrier.
+
+* `CARRIER` (Default empty)
+
+   Configure the board the Kuiper image will boot on. Together with the variable `ADI_EVAL_BOARD` it can be used to prepare \
+   the boot partition during build time with the required ADI project and carrier.
  
 * `EXPORT_SOURCES` (Default: n)
 
@@ -321,8 +331,9 @@ maintenance and customization.
  - **07.export-stage** - this stage downloads sources for the ADI tools, debootstrap command 
    and all packages installed in Kuiper. The sources can be found in `kuiper-volume/sources` inside the cloned repository on you machine. 
    This stage installs the 'extend-rootfs' script that extends the rootfs partition to the dimension of the SD 
-   card. This is also the stage where the scripts for adi update tools are installed in the Kuiper image.
-   After this stage the full Kuiper image is built and exported. It can be found in `kuiper-volume/`. 
+   card. Additionally, during this stage the boot partition is prepared with the required boot files corresponding to the variables 
+   from config file: `ADI_EVAL_BOARD` and `CARRIER`, making the image ready to be booted. After this stage 
+   the full Kuiper image is built and exported. It can be found in `kuiper-volume/`. 
  
 ## Kuiper versions
 

--- a/config
+++ b/config
@@ -183,6 +183,14 @@ USE_ADI_REPO_CARRIERS_BOOT=y
 #
 #
 #
+# [PREPARE BOOT FILES]*
+# Prepare boot partition with carriers boot files at build time by setting the ADI_EVAL_BOARD and the CARRIER.
+# *depends on INTEL AND XILINX BOOT FILES
+ADI_EVAL_BOARD=
+CARRIER=
+#
+#
+#
 # [SOURCES]
 # Contains sources for all packages in the rootfs.
 EXPORT_SOURCES=n

--- a/kuiper-stages.sh
+++ b/kuiper-stages.sh
@@ -62,6 +62,8 @@ export BRANCH_RPI_BOOT_FILES=${BRANCH_RPI_BOOT_FILES:-rpi-6.1.y}
 
 export USE_ADI_REPO_RPI_BOOT=${USE_ADI_REPO_RPI_BOOT:-n}
 export USE_ADI_REPO_CARRIERS_BOOT=${USE_ADI_REPO_CARRIERS_BOOT:-n}
+export ADI_EVAL_BOARD=${ADI_EVAL_BOARD:-""}
+export CARRIER=${CARRIER:-""}
 
 # Check if architecture is supported
 if [[ ! ${TARGET_ARCHITECTURE} = armhf && ! ${TARGET_ARCHITECTURE} = arm64 ]]; then

--- a/stages/07.export-stage/03.export-image/configure-setup.sh
+++ b/stages/07.export-stage/03.export-image/configure-setup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# kuiper2.0 - Embedded Linux for Analog Devices Products
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+# Author: Larisa Radu <larisa.radu@analog.com>
+
+BOOTLOADER_DEV=$1
+
+if [ "${CONFIG_XILINX_INTEL_BOOT_FILES}" = y ]; then
+	if [[ ! -z "${ADI_EVAL_BOARD}"  && ! -z "${CARRIER}" ]]; then
+	
+		# Extract project description from kuiper.json by selecting the project set in the configuration file
+		PROJECT_DESCRIPTION=$(cat ${BUILD_DIR}/boot/kuiper.json \
+					| jq '."projects"'              \
+					| jq '.[] | select(.name=="'${ADI_EVAL_BOARD}'" and .board=="'${CARRIER}'")')
+		
+		# Check if project exists
+		if [[ -z "${PROJECT_DESCRIPTION}" ]]; then
+			echo "Cannot find project ${ADI_EVAL_BOARD} for board ${CARRIER}. Setup not configured."
+		else
+			# Extract kernel path from the project description
+			kernel=$(echo "$PROJECT_DESCRIPTION" | jq -r '.kernel')
+			
+			# Copy kernel to Kuiper boot directory
+			cp -v ${BUILD_DIR}${kernel} ${BUILD_DIR}/boot
+			if [ $? -ne 0 ]; then
+				echo "Something went wrong while copying the kernel. Boot patition can't be configured."
+				exit
+			fi
+			
+			# Extract paths with boot files from the project description
+			paths=$(echo "$PROJECT_DESCRIPTION" | jq -r '.files' | jq '.[]' | jq -r '.path')
+			
+			# Add the correct prefix for all paths and copy them to Kuiper boot directory
+			paths=${paths//\/boot/${BUILD_DIR}\/boot}
+			cp -v $paths ${BUILD_DIR}/boot
+			if [ $? -ne 0 ]; then
+				echo "Something went wrong while copying boot files. Boot patition can't be configured."
+				exit
+			fi
+			
+			# Check if project platform is Intel
+			if [[ ! -z $(echo "$PROJECT_DESCRIPTION" | jq 'select(.platform == "intel")') ]]; then
+			
+				# Move copied extlinux.conf to extlinux folder
+				mv -v ${BUILD_DIR}/boot/extlinux.conf ${BUILD_DIR}/boot/extlinux/
+				
+				# Extract preloader file from the project description
+				preloader=$(echo "$PROJECT_DESCRIPTION" | jq -r '.preloader')
+				
+				# Write preloader file to corresponding image partition
+				dd if=${BUILD_DIR}${preloader} of=${BOOTLOADER_DEV} status=progress
+				if [ $? -ne 0 ]; then
+					echo "Something went wrong while copying the preloader. Boot patition can't be configured."
+					exit
+				fi
+			fi	
+			echo "Successfully prepared boot partition for running project ${ADI_EVAL_BOARD} on ${CARRIER}."
+		fi
+	else
+		echo "Setup won't be configured because setup variables are null."
+	fi
+else
+	echo "Setup won't be configured because Xilinx and Intel boot files were not installed."
+fi

--- a/stages/07.export-stage/03.export-image/run.sh
+++ b/stages/07.export-stage/03.export-image/run.sh
@@ -118,6 +118,14 @@ if [ "${CONFIG_RPI_BOOT_FILES}" = y ]; then
 	sed -i "s/ROOTDEV/PARTUUID=${ROOT_PARTUUID}/" "${BUILD_DIR}/boot/cmdline.txt"
 fi
 
+# Configure setup for a specific project and board
+# Pass parameter BOOTLOADER_DEV because for Intel projects the bootloader partition needs to be written
+# The current directory is set in the parent script, so in order to find the path to the configuration script we need to do the following:
+# - get the path of the current script: BASH_SOURCE
+# - remove the name of the current script: %%/run.sh
+# - concatenate with the configuration script (because it is at the same level as the current one): /configure-setup.sh
+bash "${BASH_SOURCE%%/run.sh}"/configure-setup.sh ${BOOTLOADER_DEV}
+
 rsync -aHAXx --exclude /var/cache/apt/archives --inplace --exclude /boot "${BUILD_DIR}/" "${EXPORT_ROOTFS_DIR}/"
 rsync -rtx --inplace "${BUILD_DIR}/boot/" "${EXPORT_ROOTFS_DIR}/boot/"
 


### PR DESCRIPTION
Add option to prepare the boot partition

## Pull Request Description

The boot partition can be prepared with required boot files in order to boot a specific project on a specific board. The PROJECT_NAME and BOARD can be set in the config file. Project description is retrieved from kuiper.json. The configuration is done in 07.export-stage/03.export-image. After built, Kuiper will be ready to boot with no additional configuration.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
