### PR TITLE
stages/05.adi-tools/13.write-git-logs: Add architecture info

### DIFF
--- a/stages/05.adi-tools/13.write-git-logs/run.sh
+++ b/stages/05.adi-tools/13.write-git-logs/run.sh
@@ -9,7 +9,7 @@
 repos=$(ls ${BUILD_DIR}/usr/local/src/ | tr '\n' ' ')
 
 chroot "${BUILD_DIR}" << EOF
-	echo -n "ADI repositories in Kuiper:\n\n" >> /${ADI_REPOS}
+	echo -n "ADI repositories in Kuiper ${TARGET_ARCHITECTURE}:\n\n" >> /${ADI_REPOS}
 	for r in ${repos}; do
 		cd "/usr/local/src/\${r}"
 	


### PR DESCRIPTION
## Pull Request Description

Add architecture info in 'ADI_repos_git_info.txt'. File can be found in kuiper-volume and / (root).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
