### PR TITLE
Staging/kuiper2.0

### DIFF
--- a/stages/03.system-tweaks/04.network-tweaks/run.sh
+++ b/stages/03.system-tweaks/04.network-tweaks/run.sh
@@ -4,6 +4,12 @@
 # kuiper2.0 - Embedded Linux for Analog Devices Products
 #
 # Copyright (c) 2024 Analog Devices, Inc.
-# Author: Larisa Radu <larisa.radu@analog.com>
+# Author: Monica Constandachi <monica.constandachi@analog.com>
 
+chroot "${BUILD_DIR}" << EOF
+    if [ -e /lib/udev/rules.d/80-net-setup-link.rules ]; then
+        # Change ID_NET_NAME to eth0
+        sed -i 's/\"\$env{ID_NET_NAME}\"/\"eth0\"/g' /lib/udev/rules.d/80-net-setup-link.rules
+    fi
 
+EOF


### PR DESCRIPTION
## Pull Request Description

Fixed ethernet interface naming issue.
Added a run.sh file in stages/03.system-tweaks/04.network-tweaks
Changed /lib/udev/rules.d/80-net-setup-link.rules NAME variable to eth0.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
