### PR TITLE
Remove requirement for desktop env when installing sense-emu

### DIFF
--- a/config
+++ b/config
@@ -191,10 +191,9 @@ CARRIER=
 #
 #
 #
-# [RASPBERRY PI SPECIFIC PACKAGES]*
+# [RASPBERRY PI SPECIFIC PACKAGES]
 # Install the following RaspberryPi specific packages: raspi-config, GPIO related (pigpio, python3-gpio, raspi-gpio, python3-rpi.gpio),
 # VideoCore debugging related (vcdbg), sense-hat, sense-emu.
-# *partially depends on DESKTOP ENVIRONMENT (only sense-hat and sense-emu packages)
 INSTALL_RPI_PACKAGES=n
 #
 #

--- a/stages/07.extra-tweaks/02.install-rpi-packages/run.sh
+++ b/stages/07.extra-tweaks/02.install-rpi-packages/run.sh
@@ -8,15 +8,12 @@
 
 if [ "${INSTALL_RPI_PACKAGES}" = y ]; then
 	
-	if [ "${CONFIG_DESKTOP}" = y ]; then
-		# Copy application launcher and icon for sense_emu
-		install -d 								"${BUILD_DIR}/usr/local/share/sense"
-		install -m 644 "${BASH_SOURCE%%/run.sh}"/files/sense_emu_gui.svg 	"${BUILD_DIR}/usr/local/share/sense/"
-		install -d 								"${BUILD_DIR}/usr/local/share/applications/"
-		install -m 644 "${BASH_SOURCE%%/run.sh}"/files/sense_emu_gui.desktop 	"${BUILD_DIR}/usr/local/share/applications/"
-	else
-		echo "Sense HAT and emulator won't be installed because CONFIG_DESKTOP is set to 'n'."
-	fi
+	# Copy application launcher and icon for sense_emu
+	install -d 								"${BUILD_DIR}/usr/local/share/sense"
+	install -m 644 "${BASH_SOURCE%%/run.sh}"/files/sense_emu_gui.svg 	"${BUILD_DIR}/usr/local/share/sense/"
+	install -d 								"${BUILD_DIR}/usr/local/share/applications/"
+	install -m 644 "${BASH_SOURCE%%/run.sh}"/files/sense_emu_gui.desktop 	"${BUILD_DIR}/usr/local/share/applications/"
+
 	
 chroot "${BUILD_DIR}" << EOF
 	# Uncomment packages installation from raspi.list
@@ -33,11 +30,9 @@ chroot "${BUILD_DIR}" << EOF
 	# Install vcdbg (tool for debugging VideoCore)
 	apt install -y vcdbg
 		
-	if [ "${CONFIG_DESKTOP}" = y ]; then
-		# Install sense-hat and sense-emu
-		apt install -y sense-hat python3-sense-emu
-		yes | pip install sense-emu --break-system-packages
-	fi
+	# Install sense-hat and sense-emu
+	apt install -y sense-hat python3-sense-emu
+	yes | pip install sense-emu --break-system-packages
 		
 	# Comment package installation from raspi.list
 	sed -i 's/deb /#deb /' /etc/apt/sources.list.d/raspi.list


### PR DESCRIPTION
## Pull Request Description

Applications with GUI can be launched via ssh, no need for a desktop environment.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
