### PR TITLE
Move RPI wifi firmware installation to stage 07

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ maintenance and customization.
    - **03.system-tweaks**
    - **05.adi-tools** - substages  **13.install-linux_image_ADI-scripts**, **14.write-git-logs**
    - **06.boot-partition** - substages **01.adi-boot-files**, **02.rpi-boot-files** (depending on 'config' file), **03.add-fstab**
+   - **07.extra-tweaks** - substage **03.install-rpi-wifi-firmware** (depending on 'config' file)
    - **08.export-stage** - substages **01.extend-rootfs**, **03.export-image**
  
  * `Kuiper with desktop environment:` 

--- a/stages/04.configure-desktop-env/01.desktop-env/run.sh
+++ b/stages/04.configure-desktop-env/01.desktop-env/run.sh
@@ -20,31 +20,6 @@ chroot "${BUILD_DIR}" << EOF
 	echo "export CHROMIUM_FLAGS=\"\$CHROMIUM_FLAGS --password-store=basic\"" >> /etc/chromium.d/default-flags
 EOF
 
-	if [ "${CONFIG_RPI_BOOT_FILES}" = y ]; then
-		# Uncomment raspi.list repository
-		sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list"
-		sed -i 's/#deb /deb /' "${BUILD_DIR}/etc/apt/sources.list.d/raspi.list"
-		
-		# Install wifi firmware for Raspberry PI from raspi.list
-		# Wifi firmware package from raspi.list contains files for RPI Zero W and RPI 3 
-		# in addition to the package from Debian repository
-chroot "${BUILD_DIR}" << EOF
-		apt-get update
-		apt-get install -y firmware-brcm80211 --no-install-recommends
-EOF
-		
-		# Comment raspi.list repository
-		sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list.d/raspi.list"
-		sed -i 's/#deb /deb /' "${BUILD_DIR}/etc/apt/sources.list"
-		
-		cat ${BUILD_DIR}/etc/apt/sources.list
-		cat ${BUILD_DIR}/etc/apt/sources.list.d/raspi.list
-
-chroot "${BUILD_DIR}" << EOF
-		apt-get update
-EOF
-
-	fi
 else
 	echo "XFCE desktop environment won't be installed because CONFIG_DESKTOP is set to 'n'."
 fi

--- a/stages/07.extra-tweaks/03.install-rpi-wifi-firmware/run.sh
+++ b/stages/07.extra-tweaks/03.install-rpi-wifi-firmware/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# kuiper2.0 - Embedded Linux for Analog Devices Products
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+# Author: Larisa Radu <larisa.radu@analog.com>
+
+if [ "${CONFIG_RPI_BOOT_FILES}" = y ]; then
+	# Uncomment raspi.list repository
+	sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list"
+	sed -i 's/#deb /deb /' "${BUILD_DIR}/etc/apt/sources.list.d/raspi.list"
+		
+	# Install wifi firmware for Raspberry PI from raspi.list
+	# Wifi firmware package from raspi.list contains files for RPI Zero W and RPI 3 
+	# in addition to the package from Debian repository
+chroot "${BUILD_DIR}" << EOF
+	apt-get update
+	apt-get install -y firmware-brcm80211 --no-install-recommends
+EOF
+	
+	# Comment raspi.list repository
+	sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list.d/raspi.list"
+	sed -i 's/#deb /deb /' "${BUILD_DIR}/etc/apt/sources.list"
+		
+	cat ${BUILD_DIR}/etc/apt/sources.list
+	cat ${BUILD_DIR}/etc/apt/sources.list.d/raspi.list
+
+chroot "${BUILD_DIR}" << EOF
+	apt-get update
+	apt-get install -y wpasupplicant wireless-tools
+EOF
+
+else
+	echo "RPI wifi firmware won't be installed because CONFIG_RPI_BOOT_FILES is set to 'n'."
+fi


### PR DESCRIPTION
## Pull Request Description

RPI wifi firmware does not depend on desktop environment now, so it can be moved to stage 07.extra-tweaks/03.install-rpi-wifi-firmware

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
