### PR TITLE
stage6/03-pyadi:install pyadi-iio from latest main

### DIFF
--- a/stage6/03-pyadi/00-run.sh
+++ b/stage6/03-pyadi/00-run.sh
@@ -2,7 +2,10 @@
 
 on_chroot << EOF
 
-pip3 install pyadi-iio
+# Temporary switch installation of pyadi-iio from last release to latest main
+# pip3 install pyadi-iio
+pip3 install git+https://github.com/analogdevicesinc/pyadi-iio.git
+
 pip3 install git+https://github.com/analogdevicesinc/pyadi-dt.git
 echo "export LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}:/usr/local/lib\"" >> /home/analog/.bashrc
 ldconfig


### PR DESCRIPTION
## Pull Request Description

Temporary switch the installation of pyadi-iio from last release tag to latest main, because the most recent release is to old. Latest main contains support for iio-osc navasa profile generator and other fixes, required in next release.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
