### PR TITLE
Add docker images export on github packages

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -19,6 +19,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout Dockerfile for image building
         uses: actions/checkout@v4
         with:
@@ -66,7 +73,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: aandrisa/${{ matrix.kuiper_artifact }}:latest
           file: ci/Dockerfile
           context: .
           platforms: ${{ matrix.arch }}
+          tags: |
+            aandrisa/${{ matrix.kuiper_artifact }}:latest
+            ghcr.io/analogdevicesinc/adi-kuiper-gen/${{ matrix.kuiper_artifact }}:latest


### PR DESCRIPTION
## Pull Request Description

Export docker images of kuiper2.0 also on github packages section of the repository page.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
