### PR TITLE
03.system-tweaks: configure automounting

### DIFF
--- a/stages/03.system-tweaks/05.automount/00.install-packages/packages
+++ b/stages/03.system-tweaks/05.automount/00.install-packages/packages
@@ -1,0 +1,1 @@
+udiskie

--- a/stages/03.system-tweaks/05.automount/files/udiskie.service
+++ b/stages/03.system-tweaks/05.automount/files/udiskie.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Udiskie service for managing removable media
+After=network.target
+
+[Service]
+# Start udiskie with the following parameters to make it independent of the desktop environment:
+# --no-notify: suppresses desktop notifications
+# -f "": prevents udiskie from managing any devices
+ExecStart=/usr/bin/udiskie --no-notify -f ""
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/03.system-tweaks/05.automount/run.sh
+++ b/stages/03.system-tweaks/05.automount/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# kuiper2.0 - Embedded Linux for Analog Devices Products
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+# Author: Larisa Radu <larisa.radu@analog.com>
+
+# Add udiskie service
+install -m 644 "${BASH_SOURCE%%/run.sh}"/files/udiskie.service "${BUILD_DIR}/lib/systemd/system/"
+
+chroot "${BUILD_DIR}" << EOF
+	# Enable udiskie service to run automatically at every boot
+	systemctl enable udiskie
+EOF


### PR DESCRIPTION
## Pull Request Description

Install udiskie: lightweight automounter daemon for removable media on Linux. 
Install and enable udiskie.service file.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
