### PR TITLE
Switch to GNU Radio 3.10.5

### DIFF
--- a/stages/05.adi-tools/11.install-gnuradio/files/trixie.list
+++ b/stages/05.adi-tools/11.install-gnuradio/files/trixie.list
@@ -1,2 +1,0 @@
-deb http://deb.debian.org/debian trixie main
-#deb-src http://deb.debian.org/debian trixie main

--- a/stages/05.adi-tools/11.install-gnuradio/run.sh
+++ b/stages/05.adi-tools/11.install-gnuradio/run.sh
@@ -7,23 +7,10 @@
 # Author: Larisa Radu <larisa.radu@analog.com>
 
 if [ "${CONFIG_GNURADIO}" = y ]; then
-	# Add trixie.list to sources.list
-	install -m 644 "${BASH_SOURCE%%/run.sh}"/files/trixie.list "${BUILD_DIR}/etc/apt/sources.list.d/trixie.list"
 
-	sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list"
-
-# Install Gnuradio 3.10.8 from Debian 13 Trixie. This version contains bug fixes from ADI libraries.
+# Install Gnuradio 3.10.5
 chroot "${BUILD_DIR}" << EOF
-	apt-get update
 	apt-get install -y gnuradio gnuradio-dev --no-install-recommends
-EOF
-
-	# Comment trixie.list
-	sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list.d/trixie.list"
-	sed -i 's/#deb /deb /' "${BUILD_DIR}/etc/apt/sources.list"
-
-chroot "${BUILD_DIR}" << EOF
-		apt-get update
 EOF
 
 else

--- a/stages/08.export-stage/02.export-sources/01.deb-src-chroot/run-chroot-deb.sh
+++ b/stages/08.export-stage/02.export-sources/01.deb-src-chroot/run-chroot-deb.sh
@@ -13,11 +13,6 @@ sed -i '$ s/deb /deb-src /' /etc/apt/sources.list
 # Comment package installation from sources.list
 sed -i 's/deb /#deb /' /etc/apt/sources.list
 
-if [ "${CONFIG_GNURADIO}" = y ]; then
-	# Uncomment sources installation from trixie.list in order to download sources for Gnuradio (in case it was set to be installed).
-	sed -i 's/#deb-src /deb-src /' /etc/apt/sources.list.d/trixie.list
-fi
-
 apt update
 cd /deb-src
 for package in $(dpkg -l | awk '/ii/ { print $2 }'); do
@@ -33,11 +28,6 @@ sed -i 's/deb-src /#deb-src /' /etc/apt/sources.list
 
 # Uncomment package installation from sources.list
 sed -i 's/#deb /deb /' /etc/apt/sources.list
-
-if [ "${CONFIG_GNURADIO}" = y ]; then
-	# Comment sources installation from trixie.list
-	sed -i 's/deb-src /#deb-src /' /etc/apt/sources.list.d/trixie.list
-fi
 
 apt update
 

--- a/stages/08.export-stage/02.export-sources/run.sh
+++ b/stages/08.export-stage/02.export-sources/run.sh
@@ -28,7 +28,8 @@ if [ "${EXPORT_SOURCES}" = y ]; then
 
 	######################## ADI boot sources ######################## 
 
-	if [ "${CONFIG_XILINX_INTEL_BOOT_FILES}" = y ]; then
+	# Check if Xilinx and Intel boot files were downloaded or installed via ADI APT Package Repository
+	if [[ "${CONFIG_XILINX_INTEL_BOOT_FILES}" = y && "${USE_ADI_REPO_CARRIERS_BOOT}" = n ]]; then
 		# Extract SHAs for Linux and HDL boot files in order to download the sources of the binaries from the same commit they were built.
 		LINUX_SHA=$(sed -n 9p "${BUILD_DIR}/boot/$XILINX_INTEL_PROPERTIES" |cut -d"'" -f2)
 		HDL_SHA=$(sed -n 5p "${BUILD_DIR}/boot/$XILINX_INTEL_PROPERTIES" |cut -d"'" -f2)
@@ -38,7 +39,8 @@ if [ "${EXPORT_SOURCES}" = y ]; then
 		https://github.com/analogdevicesinc/hdl/archive/${HDL_SHA}.zip
 	fi
 
-	if [ "${CONFIG_RPI_BOOT_FILES}" = y ]; then
+	# Check if RPI boot files were downloaded or installed via ADI APT Package Repository
+	if [[ "${CONFIG_RPI_BOOT_FILES}" = y && "${USE_ADI_REPO_RPI_BOOT}" = n ]]; then
 		if [[ ! -z ${ARTIFACTORY_RPI} ]]; then
 			RPI_SHA=$(sed -n 2p "${BUILD_DIR}/boot/$RPI_ARTIFACTORY_PROPERTIES" |cut -d'=' -f2)
 		else
@@ -49,7 +51,7 @@ if [ "${EXPORT_SOURCES}" = y ]; then
 	fi
 	
 
-    ######################## Debootstrap package source ########################
+    	######################## Debootstrap package source ########################
 
 	# Download debootstrap sources
 	DEBOOTSTRAP_VERSION=$(debootstrap --version | cut -d' ' -f 2)
@@ -63,7 +65,7 @@ if [ "${EXPORT_SOURCES}" = y ]; then
 	mount --bind /kuiper-volume/sources/deb-src "${BUILD_DIR}/deb-src"
 	
 chroot "${BUILD_DIR}" << EOF
-	bash stages/07.export-stage/03.export-sources/01.deb-src-chroot/run-chroot-deb.sh
+	bash stages/08.export-stage/02.export-sources/01.deb-src-chroot/run-chroot-deb.sh
 EOF
 	umount "${BUILD_DIR}/deb-src"
 	rm -r "${BUILD_DIR}/deb-src"
@@ -76,7 +78,7 @@ EOF
 		mount --bind /kuiper-volume/sources/deb-src-rpi "${BUILD_DIR}/deb-src-rpi"
 
 chroot "${BUILD_DIR}" << EOF
-		bash stages/07.export-stage/03.export-sources/01.deb-src-chroot/run-chroot-rpi.sh "${CONFIG_DESKTOP}"
+		bash stages/08.export-stage/02.export-sources/01.deb-src-chroot/run-chroot-rpi.sh "${CONFIG_DESKTOP}"
 EOF
 		umount "${BUILD_DIR}/deb-src-rpi"
 		rm -r "${BUILD_DIR}/deb-src-rpi"


### PR DESCRIPTION
## Pull Request Description

Switch to GNU Radio 3.10.5 (from Debian 12) because the previous installed version (GNU Radio 3.10.8 from Debian 13) breaks packages.
Update the flow for exporting sources.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
