### PR TITLE
Update kernel version in license and remote HDL TB repo since it isn't part of Kuiper image

### DIFF
--- a/stage8/00-license-generation/00-run.sh
+++ b/stage8/00-license-generation/00-run.sh
@@ -261,9 +261,8 @@ echo "<th>Location</th>" >> ${FILE}
 echo "</tr>" >> ${FILE}
 echo "</thead>" >> ${FILE}
 echo "<tbody>" >> ${FILE}
-package_table_items $((var++)) "Linux" "5.10" "GPLv2" "https://github.com/analogdevicesinc/linux"
+package_table_items $((var++)) "Linux" "5.15" "GPLv2" "https://github.com/analogdevicesinc/linux"
 package_table_items $((var++)) "HDL"   " "    "GPL/LGPL/BSD" "https://github.com/analogdevicesinc/hdl"
-package_table_items $((var++)) "HDL Testbenches" " " "GPL" "https://github.com/analogdevicesinc/testbenches"
 package_table_items $((var++)) "LibIIO" " " "LGPL-2.1/GPL-2.0" "https://github.com/analogdevicesinc/libiio"
 package_table_items $((var++)) "IIO Oscilloscope" " " "GPL-2.0" "https://github.com/analogdevicesinc/iio-oscilloscope"
 package_table_items $((var++)) "Scopy" " " "GPL-3.0" "https://github.com/analogdevicesinc/scopy"


### PR DESCRIPTION
## Pull Request Description

Update kernel version in license and remove HDL TB repo since it isn't part of Kuiper image

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
