### PR TITLE
06.boot-partition/02.rpi-boot-files/config: Add support for CM5

### DIFF
--- a/stages/06.boot-partition/02.rpi-boot-files/files/config.txt
+++ b/stages/06.boot-partition/02.rpi-boot-files/files/config.txt
@@ -24,4 +24,7 @@ disable_overscan=1
 # Run as fast as firmware / board allows
 arm_boost=1
 
+[cm5]
+dtoverlay=dwc2,dr_mode=host
+
 autologin-user=analog


### PR DESCRIPTION
## Pull Request Description

Enable DWC2 host mode support for CM5 by default

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
