### PR TITLE
.github/workflows: separate export of the image and meta files

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -42,7 +42,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: kuiper2_0-build.yml
           branch: main
-          name: ${{ matrix.kuiper_artifact }}
+          name: ${{ matrix.kuiper_artifact }}_image
           repo: analogdevicesinc/adi-kuiper-gen
 
       - name: Create .tar file

--- a/.github/workflows/kuiper2_0-build.yml
+++ b/.github/workflows/kuiper2_0-build.yml
@@ -51,11 +51,18 @@ jobs:
           sudo bash build-docker.sh
           ls kuiper-volume/*.zip >/dev/null 2>&1 && exit 0 || exit 2
       - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}_image
+          path: ${{ github.workspace }}/kuiper-volume/*.zip
+      - name: Upload meta
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ github.workspace }}/kuiper-volume
+          name: ${{ env.ARTIFACT_NAME }}_meta
+          path: |
+            ${{ github.workspace }}/kuiper-volume
+            !${{ github.workspace }}/kuiper-volume/*.zip
 
   Trigger_workflow:
     needs: Build


### PR DESCRIPTION
## Pull Request Description

Export two artifacts, one that contains only the zip with the image and the other with the meta files generated during build time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
