### PR TITLE
08.export-stage/02.export-sources: Download debootstrap sources via apt

### DIFF
--- a/stages/08.export-stage/02.export-sources/run.sh
+++ b/stages/08.export-stage/02.export-sources/run.sh
@@ -53,11 +53,15 @@ if [ "${EXPORT_SOURCES}" = y ]; then
 
     	######################## Debootstrap package source ########################
 
+	sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/debian.sources
+	apt update
+
+	cd kuiper-volume/sources/debootstrap/
+
 	# Download debootstrap sources
-	DEBOOTSTRAP_VERSION=$(debootstrap --version | cut -d' ' -f 2)
-	wget -vO /kuiper-volume/sources/debootstrap/debootstrap.zip \
-	https://salsa.debian.org/installer-team/debootstrap/-/archive/debian/${DEBOOTSTRAP_VERSION}/debootstrap-debian-${DEBOOTSTRAP_VERSION}.zip
+	apt-get --download-only source debootstrap
 	
+	cd /
 	
 	######################## Debian packages sources ########################
 	


### PR DESCRIPTION
## Pull Request Description

Salsa link for debootstrap sources was broken. Changed to downloading sources via apt.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
