### PR TITLE
03.system-tweaks: disable Predictable Network Interface names

### DIFF
--- a/stages/03.system-tweaks/04.network-tweaks/run.sh
+++ b/stages/03.system-tweaks/04.network-tweaks/run.sh
@@ -5,11 +5,10 @@
 #
 # Copyright (c) 2024 Analog Devices, Inc.
 # Author: Monica Constandachi <monica.constandachi@analog.com>
+# Author: Larisa Radu <larisa.radu@analog.com>
 
 chroot "${BUILD_DIR}" << EOF
-    if [ -e /lib/udev/rules.d/80-net-setup-link.rules ]; then
-        # Change ID_NET_NAME to eth0
-        sed -i 's/\"\$env{ID_NET_NAME}\"/\"eth0\"/g' /lib/udev/rules.d/80-net-setup-link.rules
-    fi
-
+	# Link files that enable Predictable Network Interface names to null
+	ln -sf /dev/null /etc/systemd/network/99-default.link
+	ln -sf /dev/null /etc/systemd/network/73-usb-net-by-mac.link
 EOF


### PR DESCRIPTION
## Pull Request Description

Disable Predictable Network Interface names by linking the "99-default.link" and "73-usb-net-by-mac.link" to /dev/null.
The corresponding files are located in "/usr/lib/systemd/network", but because udev follows this precedence:
- /etc/systemd/network - highest priority
- /run/systemd/network
- /usr/lib/systemd/network
The best option is to link to null "99-default.link" and "73-usb-net-by-mac.link" files from the folder with the higher priority, even in they were not existent there before. This ensures that any other change made to the system will not override the option to disable Predictable Network Interface names unless explicitly removing the created links.

The previous implementation overrode predictable network interface names, which resulted in race conditions between services that depended on network availability.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
