### PR TITLE
07.extra-tweaks/03.install-rpi-firmware: Add bluetooth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ The default configuration includes only the essential packages and configuration
   - Substage **02.rpi-boot-files** - Raspberry Pi boot files (if enabled)
   - Substage **03.add-fstab** - Filesystem table configuration
 - **07.extra-tweaks**
-  - Substage **03.install-rpi-wifi-firmware** - WiFi support (if needed)
+  - Substage **03.install-rpi-firmware** - WiFi and bluetooth support (if needed)
 - **08.export-stage**
   - Substage **01.extend-rootfs** - Root filesystem expansion script
   - Substage **03.generate-license** License generation

--- a/stages/07.extra-tweaks/03.install-rpi-firmware/run.sh
+++ b/stages/07.extra-tweaks/03.install-rpi-firmware/run.sh
@@ -10,27 +10,28 @@ if [ "${CONFIG_RPI_BOOT_FILES}" = y ]; then
 	# Uncomment raspi.list repository
 	sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list"
 	sed -i 's/#deb /deb /' "${BUILD_DIR}/etc/apt/sources.list.d/raspi.list"
-		
-	# Install wifi firmware for Raspberry PI from raspi.list
-	# Wifi firmware package from raspi.list contains files for RPI Zero W and RPI 3 
+
+	# Install bluetooth and wifi firmware for Raspberry PI from raspi.list
+	# Wifi firmware package from raspi.list contains files for RPI Zero W and RPI 3
 	# in addition to the package from Debian repository
 chroot "${BUILD_DIR}" << EOF
 	apt-get update
-	apt-get install -y firmware-brcm80211 --no-install-recommends
+	apt-get install -y firmware-brcm80211 bluez-firmware --no-install-recommends
 EOF
-	
+
 	# Comment raspi.list repository
 	sed -i 's/deb /#deb /' "${BUILD_DIR}/etc/apt/sources.list.d/raspi.list"
 	sed -i 's/#deb /deb /' "${BUILD_DIR}/etc/apt/sources.list"
-		
+
 	cat ${BUILD_DIR}/etc/apt/sources.list
 	cat ${BUILD_DIR}/etc/apt/sources.list.d/raspi.list
 
+# Install graphical bluetooth and wifi managers
 chroot "${BUILD_DIR}" << EOF
 	apt-get update
-	apt-get install -y wpasupplicant wireless-tools
+	apt-get install -y wpasupplicant wireless-tools blueman
 EOF
 
 else
-	echo "RPI wifi firmware won't be installed because CONFIG_RPI_BOOT_FILES is set to 'n'."
+	echo "RPI wifi and bluetooth firmware won't be installed because CONFIG_RPI_BOOT_FILES is set to 'n'."
 fi


### PR DESCRIPTION
## Pull Request Description

Install bluez-firmware: firmware files for Bluetooth adapters and legacy Broadcom chips
Install blueman: graphical Bluetooth manager for Linux desktops

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
