### PR TITLE
05.adi-tools/11.install-gnuradio: Fix PYTHONPATH

### DIFF
--- a/stages/05.adi-tools/11.install-gnuradio/run.sh
+++ b/stages/05.adi-tools/11.install-gnuradio/run.sh
@@ -11,6 +11,11 @@ if [ "${CONFIG_GNURADIO}" = y ]; then
 # Install Gnuradio 3.10.5
 chroot "${BUILD_DIR}" << EOF
 	apt-get install -y gnuradio gnuradio-dev --no-install-recommends
+
+	# Set the Python path to deb packages when launching GNURadio from both terminal and GUI
+	sed -i 's|^Exec=gnuradio-companion|Exec=env PYTHONPATH=/usr/lib/python3/dist-packages:\$PYTHONPATH gnuradio-companion|' /usr/share/applications/gnuradio-grc.desktop
+	echo "alias gnuradio-companion='PYTHONPATH=/usr/lib/python3/dist-packages:\$PYTHONPATH gnuradio-companion'" >> /etc/bash.bashrc
+
 EOF
 
 else


### PR DESCRIPTION
Force GNU Radio to launch with deb python packages instead of pip version.

## Pull Request Description

GNU Radio requires the deb numpy package. A newer numpy version installed via pip for pyadi-iio takes precedence at runtime, causing incompatibility issues and leading to import errors when launching GNU Radio

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
