### PR TITLE
03.system-tweaks/02.root-autologin: Reset terminal text formatting

### DIFF
--- a/stages/03.system-tweaks/02.root-autologin/run.sh
+++ b/stages/03.system-tweaks/02.root-autologin/run.sh
@@ -20,4 +20,7 @@ chroot "${BUILD_DIR}" << EOF
 	echo "ttyS0" >> /etc/securetty
 	echo "ttyGS0" >> /etc/securetty
 	echo "ttyGS1" >> /etc/securetty
+
+	# Add an ANSI reset code at the begining of /etc/issue to clear any text formatting from boot messages
+	sed -i '1s|^|\\\e[0m|' /etc/issue
 EOF


### PR DESCRIPTION
## Pull Request Description

Add an ANSI reset code at the begining of /etc/issue to clear any text formatting from boot messages.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
