### PR TITLE
03.system-tweaks/04.network-tweaks: Add custom NM profiles

### DIFF
--- a/stages/03.system-tweaks/04.network-tweaks/files/Wired connection 1
+++ b/stages/03.system-tweaks/04.network-tweaks/files/Wired connection 1
@@ -1,0 +1,19 @@
+[connection]
+id=Wired connection 1
+type=ethernet
+autoconnect-priority=10
+interface-name=eth0
+
+[ethernet]
+
+[ipv4]
+dhcp-timeout=5
+link-local=1
+may-fail=false
+method=auto
+
+[ipv6]
+addr-gen-mode=default
+method=disabled
+
+[proxy]

--- a/stages/03.system-tweaks/04.network-tweaks/files/eth0-linklocal
+++ b/stages/03.system-tweaks/04.network-tweaks/files/eth0-linklocal
@@ -1,0 +1,16 @@
+[connection]
+id=eth0-linklocal
+type=ethernet
+autoconnect-priority=5
+interface-name=eth0
+
+[ethernet]
+
+[ipv4]
+method=link-local
+
+[ipv6]
+addr-gen-mode=default
+method=disabled
+
+[proxy]

--- a/stages/03.system-tweaks/04.network-tweaks/run.sh
+++ b/stages/03.system-tweaks/04.network-tweaks/run.sh
@@ -7,6 +7,10 @@
 # Author: Monica Constandachi <monica.constandachi@analog.com>
 # Author: Larisa Radu <larisa.radu@analog.com>
 
+# Add custom NetworkManager connection profiles
+install -m 600 "${BASH_SOURCE%%/run.sh}/files/eth0-linklocal"		"${BUILD_DIR}/etc/NetworkManager/system-connections/"
+install -m 600 "${BASH_SOURCE%%/run.sh}/files/Wired connection 1"	"${BUILD_DIR}/etc/NetworkManager/system-connections/"
+
 chroot "${BUILD_DIR}" << EOF
 	# Link files that enable Predictable Network Interface names to null
 	ln -sf /dev/null /etc/systemd/network/99-default.link


### PR DESCRIPTION
## Pull Request Description

Created nmconnection files for eth0 to handle IP assignments when network cables are plugged into different types of hosts: DHCP servers or standalone PCs. "Wired connection 1":
- the default connection created by NetworkManager
- tries DHCP on eth0 (method=auto)
- fails in 5 seconds if no DHCP server is available (dhcp-timeout=5)
- has a high priority (autoconnect-priority=10) making it the preferred connection
- won't consider it a failure (may-fail=false) and will keep retrying if a DHCP server appears
- IPV6 is disabled

"eth0-linklocal":
- the custom connection profile for IP assignment via link-local for standalone PCs
- uses method=link-local for addressing 169.254.x.x range
- lower autoconnect-priority (5) so it only activates if the higher-priority one ("Wired connection 1") fails
- IPV6 is disabled

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
