### PR TITLE
05.adi-tools/12.install-gr-m2k: Temporarily fix gmp

### DIFF
--- a/stages/05.adi-tools/12.install-gr-m2k/run.sh
+++ b/stages/05.adi-tools/12.install-gr-m2k/run.sh
@@ -6,17 +6,45 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # Author: Larisa Radu <larisa.radu@analog.com>
 
+# Temporary Fix: Modify FindGMP.cmake to avoid arm64 compilation issue
+export FINDGMP_PATH="/usr/lib/aarch64-linux-gnu/cmake/gnuradio/FindGMP.cmake"
+
 if [ "${CONFIG_GRM2K}" = y ]; then
 	if [[ "${CONFIG_LIBIIO}" = y  && "${CONFIG_LIBM2K}" = y && "${CONFIG_GNURADIO}" = y ]]; then
 
 chroot "${BUILD_DIR}" << EOF
 		cd /usr/local/src
 
+		# Temporary Fix: Modify FindGMP.cmake to avoid arm64 compilation issue
+		if [ -f "${FINDGMP_PATH}" ]; then
+			if grep -q "pkg_check_modules(PC_GMP" "$FINDGMP_PATH"; then
+				echo "Problematic pkg_check_modules line found in $FINDGMP_PATH - applying fix"
+
+				# Create backup
+				cp "$FINDGMP_PATH" "${FINDGMP_PATH}.orig"
+
+				# Remove problematic pkg_check_modules line
+				sed -i '/pkg_check_modules(PC_GMP/d' "$FINDGMP_PATH"
+
+				echo "FindGMP.cmake pkg_check_modules fix applied"
+			else
+				echo "pkg_check_modules line not found - no need for fix"
+			fi
+		else
+			echo "FindGMP.cmake not found at $FINDGMP_PATH - continuing without fix"
+		fi
+
 		# Clone gr-m2k
 		git clone -b ${BRANCH_GRM2K} ${GITHUB_ANALOG_DEVICES}/gr-m2k.git
-	
+
 		# Install gr-m2k
 		cd gr-m2k && cmake ${CONFIG_GRM2K_CMAKE_ARGS} && cd build && make -j $NUM_JOBS && make install
+
+		# Temporary Fix: Restore original FindGMP.cmake
+		if [ -f "${FINDGMP_PATH}" ] && [ -f "${FINDGMP_PATH}.orig" ]; then
+			mv "${FINDGMP_PATH}.orig" "$FINDGMP_PATH"
+			echo "Restored original FindGMP.cmake"
+		fi
 EOF
 
 	else


### PR DESCRIPTION
Temorary fix until I manage the get the better, elegant fix into the gnuradio package.

The build for gr-m2k used to fail because, when configuring gnuradio, the cmake project couldn't find the gmp libraries.

The problematic search is implemented in
/usr/lib/aarch64-linux-gnu/cmake/gnuradio/FindGMP.cmake.

Function pkg_check_modules is used to search for the gmp libraries initially but fails. It is followed by fallback calls of find_library. Those also fail because of some magic cmake internal variable probably set by the failed pkg_check_modules function initial call.

The fallback functions work fine on their own.

In order to temporary solve this issue, remove the pkg_check_modules call from FindGMP.cmake. After gr-m2k is installed, restore the original FindGMP.cmake file.

## PR Type
- [x] Bug fix (change that fixes an issue)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
