### PR TITLE
build-docker: Remove container if build was interrupted

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -14,6 +14,14 @@ IMAGE_NAME="debian_${DEBIAN_VERSION}_rootfs"
 CONTAINER_NAME=${CONTAINER_NAME:-"${IMAGE_NAME}_container"}
 PRESERVE_CONTAINER=${PRESERVE_CONTAINER:-n}
 
+cleanup() {
+	docker rm -fv ${CONTAINER_NAME}
+	exit 1
+}
+
+# Remove container if build was interrupted or cancelled
+trap cleanup SIGINT SIGTERM
+
 # Check if the script is run as root
 if [ "$(id -u)" != "0" ] ; then
 	echo "This script must be run as root"


### PR DESCRIPTION
## Pull Request Description

Remove the container and attached volume when a build is interrupted.

SIGINT: interrupt signal sent when a user presses Ctrl+C in the terminal to manually stop a running process
SIGTERM: shutdown request sent by a program, service of the operating system to ask a process to terminate

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
