### PR TITLE
06.boot-partition: Add README file in image

### DIFF
--- a/stages/06.boot-partition/03.add-fstab/files/README.txt
+++ b/stages/06.boot-partition/03.add-fstab/files/README.txt
@@ -1,0 +1,64 @@
+INFO: If you are already booting the image on a hardware platfom, run 'sudo configure-setup.sh --help' and follow the steps for automatic preparation of the boot partition.
+Check this link for more informations: https://analogdevicesinc.github.io/adi-kuiper-gen/hardware-configuration.html
+If not, check the manual steps below:
+
+Platform-Specific Manual Steps
+
+AMD/Xilinx Platforms
+
+For Zynq projects, copy these files to the root of the BOOT FAT32 partition:
+    <target>/BOOT.BIN - First stage bootloader with FPGA bitstream
+    <target>/<specific_folder>/devicetree.dtb - Device tree for your specific project
+    zynq-common/uImage - Kernel image for Zynq platforms
+    zynq-common/uEnv.txt - U-Boot environment configuration
+
+For ZynqMP projects, copy these files to the root of the BOOT FAT32 partition:
+    <target>/BOOT.BIN - First stage bootloader with FPGA bitstream
+    <target>/<specific_folder>/system.dtb - Device tree for your specific project
+    zynqmp-common/Image - Kernel image for ZynqMP platforms
+    zynqmp-common/uEnv.txt - U-Boot environment configuration
+
+For Versal projects, copy these files to the root of the BOOT FAT32 partition:
+    <target>/BOOT.BIN - Platform Loader and Manager (PLM) and boot components
+    <target>/<specific_folder>/system.dtb - Device tree for your specific project
+    <target>/boot.scr - U-Boot script for Versal boot sequence
+    versal-common/Image - Kernel image for Versal platforms
+
+
+Intel/Altera Platforms
+
+For Arria10 SoC projects, copy these files to the root of the BOOT FAT32 partition:
+    <target>/fit_spl_fpga.itb - FPGA configuration and SPL image
+    <target>/socfpga_arria10_socdk_sdmmc.dtb - Device tree
+    <target>/u-boot.img - U-Boot proper
+    socfpga_arria10_common/zImage - Kernel image
+Create an extlinux folder in the boot partition and copy socfpga_arria10_common/extlinux.conf into it
+Write the preloader (replace mmcblkXp3 with your actual device):
+    'sudo dd if=<target>/fit_spl_fpga.itb of=/dev/mmcblk0p3 status=progress'
+
+For Cyclone5 projects, copy these files to the root of the BOOT FAT32 partition:
+    <target>/soc_system.rbf - FPGA bitstream
+    <target>/socfpga.dtb - Device tree
+    <target>/u-boot.scr - U-Boot script
+    <target>/u-boot-with-spl.sfp - SPL and U-Boot combined
+    socfpga_cyclone5_common/zImage - Kernel image
+Create an extlinux folder in the boot partition and copy socfpga_cyclone5_common/extlinux.conf into it
+Write the preloader (replace mmcblkXp3 with your actual device):
+    'sudo dd if=<target>/u-boot-with-spl.sfp of=/dev/mmcblk0p3 status=progress'
+    
+
+RaspberryPi
+
+For loading RPI overlays the are 2 methods:
+  - you can manually edit /boot/config.txt by adding a new line with
+    "dtoverlay=<overlay_name>[,<overlay_arguments>]"
+  - or you can load an overlay dinamically, after RPI booted, by opening a
+    terminal and typing "sudo dtoverlay <overlay_name>[,<overlay_arguments>]"
+In both cases, there needs to be specified only the overlay name, without extension and path.
+Overlays binaries (*.dtbo) can be found in /boot/overlays.
+
+INFO: After editing the config.txt file you need to reboot you device so that the changes are loaded.
+
+Documentation:
+    https://analogdevicesinc.github.io/adi-kuiper-gen/
+    https://analog.com/en/design-center/evaluation-hardware-and-software/software/kuiper-linux.html

--- a/stages/06.boot-partition/03.add-fstab/run.sh
+++ b/stages/06.boot-partition/03.add-fstab/run.sh
@@ -7,3 +7,4 @@
 # Author: Larisa Radu <larisa.radu@analog.com>
 
 install -v -m 644 "${BASH_SOURCE%%/run.sh}"/files/fstab "${BUILD_DIR}/etc/fstab"
+install -v -m 644 "${BASH_SOURCE%%/run.sh}"/files/README.txt "${BUILD_DIR}/boot/"


### PR DESCRIPTION
## Pull Request Description

Add a README file in the boot partition now that boot files will be installed separately from ADI APT repo.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
