### PR TITLE
06.boot-partition/02.rpi-boot-files/arm64/config.txt: Use kms driver

### DIFF
--- a/stages/06.boot-partition/02.rpi-boot-files/files/arm64/config.txt
+++ b/stages/06.boot-partition/02.rpi-boot-files/files/arm64/config.txt
@@ -14,7 +14,7 @@ hdmi_force_hotplug=1
 display_auto_detect=1
 
 # Enable DRM VC4 V3D driver
-dtoverlay=vc4-fkms-v3d
+dtoverlay=vc4-kms-v3d
 max_framebuffers=2
 
 # Run in 64-bit mode


### PR DESCRIPTION
For the RPi 5, the KMS driver is the recommended and primary driver, as FKMS is no longer supported on this board.

RPi 4 also supports the KMS driver.

## PR Type
- [x] Bug fix (change that fixes an issue)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR