### PR TITLE
01.bootstrap: Don't update-binfmts if running on an arm host

### DIFF
--- a/stages/01.bootstrap/run.sh
+++ b/stages/01.bootstrap/run.sh
@@ -6,7 +6,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # Author: Larisa Radu <larisa.radu@analog.com>
 
-update-binfmts --enable qemu-arm
+if [[ "$(uname -m)" != "aarch64" && "$(uname -m)" != "arm*" ]]; then
+	update-binfmts --enable qemu-arm
+fi
 
 mkdir "${BUILD_DIR}"
 debootstrap --arch=${TARGET_ARCHITECTURE} \
@@ -14,7 +16,9 @@ debootstrap --arch=${TARGET_ARCHITECTURE} \
 			--include=ca-certificates \
 			--keyring "/usr/share/keyrings/debian-archive-"${DEBIAN_VERSION}"-stable.gpg" "${DEBIAN_VERSION}" "${BUILD_DIR}"
 
-cp /usr/bin/qemu-arm-static "${BUILD_DIR}"/usr/bin
+if [[ "$(uname -m)" != "aarch64" && "$(uname -m)" != "arm*" ]]; then
+	cp /usr/bin/qemu-arm-static "${BUILD_DIR}"/usr/bin
+fi
 
 # Add adi-repo.list to sources.list
 install -m 644 "${BASH_SOURCE%%/run.sh}"/files/adi-repo.list "${BUILD_DIR}/etc/apt/sources.list.d/adi-repo.list"


### PR DESCRIPTION
## Pull Request Description

Add an if clause to only activate the `qemu-arm` binfmt on non-arm hosts. On arm hosts, no emulation is needed. Attempting to activate the arm binfmt on native arm hosts leads to an error because the `qemu-user-binfmt` package doesn't contain binfmt configs for their respective host architecture (i.e. the amd64 package doesn't contain qemu-x86_64, the arm64 package doesn't contain qemu-arm, etc.).

This makes it possible to build Kuiper images on an arm64 host, allowing for build speedups by removing the emulation layer.

It should also allow building of 32 bit images on armv6/v7/v7l hosts.

Building armhf images on an arm64 host
--------------------------------------

Note that building armhf images requires the host run a kernel with 4k pages, such as `kernel8.img` instead of `kernel2712.img` on the Raspberry Pi 5. The kernel included in the image can be anything. On a 16k page kernel, many binaries will fail to load inside the chroot because of page alignment. The opposite is not an issue: binaries with 16k pages are compatible with a kernel with 4k pages.

See: https://github.com/raspberrypi/bookworm-feedback/issues/107

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
