### PR TITLE
.github/workflows: build gmsl kuiper image

### DIFF
--- a/.github/workflows/gmsl-image-build.yml
+++ b/.github/workflows/gmsl-image-build.yml
@@ -1,0 +1,14 @@
+name: GMSL Kuiper Image Build
+on:
+  workflow_dispatch:
+    inputs:
+      linux_run_id:
+        description: 'Run ID of the linux kernel build workflow'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Start Kuiper Image Build."


### PR DESCRIPTION
## Pull Request Description

GitHub workflow_dispatch API requires the workflow file to exist on the default branch. This file is a placeholder to satisfy the requirement and the actual workflow logic is on the gmsl-rpi-6.13.y branch.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
