### PR TITLE
ci: Enable builds for custom images

### DIFF
--- a/.github/workflows/kuiper2_0-build.yml
+++ b/.github/workflows/kuiper2_0-build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'custom/**'
     paths-ignore:
       - 'docs/**'
       - 'README.md'
@@ -110,7 +111,7 @@ jobs:
   Trigger_workflow:
     needs: Build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Trigger docker build


### PR DESCRIPTION
Add 'custom/**' to the push branch triggers so that pushing to any branch under custom/ triggers the full Kuiper build matrix. Restrict the Trigger_workflow job to main-only pushes to prevent custom branches from triggering the Docker image build.

Signed-off-by: Ioana Chelaru <ioana-gabriela.chelaru@analog.com>
