### PR TITLE
docs: Use binfmt-based QEMU for cross-arch builds

### DIFF
--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -39,7 +39,7 @@ Required Software
    .. code-block:: bash
 
       sudo apt-get update
-      sudo apt-get install qemu-user-static binfmt-support
+      sudo apt-get install qemu-user-binfmt binfmt-support
 
    **Note**: The build script automatically registers QEMU emulation handlers
    when building ARM images on x86 systems. This requires Docker to run with

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -31,7 +31,7 @@ Required Software
    - These packages are necessary to build ARM-based images on x86 systems:
 
      - ``qemu-user-static``: For emulating ARM architecture
-     - ``binfmt_misc``: Kernel module to run binaries from different 
+     - ``binfmt-support``: To enable execution of binaries from different
        architectures
 
    You can install them on Debian/Ubuntu with:
@@ -41,14 +41,6 @@ Required Software
       sudo apt-get update
       sudo apt-get install qemu-user-static binfmt-support
 
-   To ensure the binfmt_misc module is loaded:
-
-   .. code-block:: bash
-
-      sudo modprobe binfmt_misc
-
-   If using WSL, you may need to enable the service:
-
-   .. code-block:: bash
-
-      sudo update-binfmts --enable
+   **Note**: The build script automatically registers QEMU emulation handlers
+   when building ARM images on x86 systems. This requires Docker to run with
+   privileged access (using ``sudo`` as shown in the build instructions).

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -38,7 +38,7 @@ on x86 systems. If you encounter the errors above:
 
 
 
-3. Make sure you're running the build script with ``sudo`` to allow Docker
+2. Make sure you're running the build script with ``sudo`` to allow Docker
    privileged access for automatic QEMU registration.
 
 4. If the automatic registration fails, you can manually register QEMU handlers:

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -36,7 +36,6 @@ on x86 systems. If you encounter the errors above:
       sudo apt-get install qemu-user-binfmt binfmt-support
 
 
-   .. code-block:: bash
 
       ls /usr/bin/qemu-arm-static
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -8,17 +8,11 @@ Troubleshooting
 Cross-Architecture Build Issues
 -------------------------------
 
-If you encounter errors related to ARM emulation, first ensure you've properly 
-set up the prerequisites as described in the 
+If you encounter errors related to ARM emulation, first ensure you've properly
+set up the prerequisites as described in the
 :doc:`Prerequisites section <prerequisites>`.
 
 Common error messages and their solutions:
-
-.. code-block:: text
-
-   update-binfmts: warning: Couldn't load the binfmt_misc module.
-
-OR
 
 .. code-block:: text
 
@@ -32,19 +26,29 @@ OR
 
 **Solution**:
 
-1. Verify these specific files exist on your system:
+The build script automatically registers QEMU emulation handlers when building
+on x86 systems. If you encounter the errors above:
 
-   .. code-block:: bash
-
-      /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko
-      /usr/bin/qemu-arm-static
-
-2. If necessary, install the missing packages and load the module:
+1. Ensure the required packages are installed:
 
    .. code-block:: bash
 
       sudo apt-get install qemu-user-static binfmt-support
-      sudo modprobe binfmt_misc
+
+2. Verify that ``qemu-user-static`` is properly installed:
+
+   .. code-block:: bash
+
+      ls /usr/bin/qemu-arm-static
+
+3. Make sure you're running the build script with ``sudo`` to allow Docker
+   privileged access for automatic QEMU registration.
+
+4. If the automatic registration fails, you can manually register QEMU handlers:
+
+   .. code-block:: bash
+
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 ----
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -33,7 +33,7 @@ on x86 systems. If you encounter the errors above:
 
    .. code-block:: bash
 
-      sudo apt-get install qemu-user-static binfmt-support
+      sudo apt-get install qemu-user-binfmt binfmt-support
 
 2. Verify that ``qemu-user-static`` is properly installed:
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -37,7 +37,6 @@ on x86 systems. If you encounter the errors above:
 
 
 
-      ls /usr/bin/qemu-arm-static
 
 3. Make sure you're running the build script with ``sudo`` to allow Docker
    privileged access for automatic QEMU registration.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -35,7 +35,6 @@ on x86 systems. If you encounter the errors above:
 
       sudo apt-get install qemu-user-binfmt binfmt-support
 
-2. Verify that ``qemu-user-static`` is properly installed:
 
    .. code-block:: bash
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -41,7 +41,7 @@ on x86 systems. If you encounter the errors above:
 2. Make sure you're running the build script with ``sudo`` to allow Docker
    privileged access for automatic QEMU registration.
 
-4. If the automatic registration fails, you can manually register QEMU handlers:
+3. If the automatic registration fails, you can manually register QEMU handlers:
 
    .. code-block:: bash
 


### PR DESCRIPTION
Update documentation prerequisites.rst and troubleshooting.rst to reflect the transition to binfmt-based emulation inside the container.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes.
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR.
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
