### PR TITLE
Use binfmt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
         parted moreutils e2fsprogs\
-        coreutils qemu-user-static debootstrap zip dosfstools \
+        coreutils qemu-user-binfmt debootstrap zip dosfstools \
         rsync grep xxd kmod bc udev jq \
         build-essential gcc-arm-linux-gnueabihf \
         u-boot-tools gcc-aarch64-linux-gnu gnupg \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -34,6 +34,10 @@ if [[ ! ${DEBIAN_VERSION} = bookworm && ! ${DEBIAN_VERSION} = bullseye && ! ${DE
 	exit 1
 fi
 
+if [[ "$(uname -m)" != "aarch64" && "$(uname -m)" != "arm*" ]]; then
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+fi
+
 # Build docker image
 docker build --build-arg BASE_IMAGE="${BASE_IMAGE}" -t ${IMAGE_NAME} .
 

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -30,8 +30,8 @@ Required Software
 
    - These packages are necessary to build ARM-based images on x86 systems:
 
-     - ``qemu-user-static``: For emulating ARM architecture
-     - ``binfmt_misc``: Kernel module to run binaries from different 
+     - ``qemu-user-binfmt``: For emulating ARM architecture
+     - ``binfmt-support``: To enable execution of binaries from different
        architectures
 
    You can install them on Debian/Ubuntu with:
@@ -39,16 +39,8 @@ Required Software
    .. code-block:: bash
 
       sudo apt-get update
-      sudo apt-get install qemu-user-static binfmt-support
+      sudo apt-get install qemu-user-binfmt binfmt-support
 
-   To ensure the binfmt_misc module is loaded:
-
-   .. code-block:: bash
-
-      sudo modprobe binfmt_misc
-
-   If using WSL, you may need to enable the service:
-
-   .. code-block:: bash
-
-      sudo update-binfmts --enable
+   **Note**: The build script automatically registers QEMU emulation handlers
+   when building ARM images on x86 systems. This requires Docker to run with
+   privileged access (using ``sudo`` as shown in the build instructions).

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -8,17 +8,11 @@ Troubleshooting
 Cross-Architecture Build Issues
 -------------------------------
 
-If you encounter errors related to ARM emulation, first ensure you've properly 
-set up the prerequisites as described in the 
+If you encounter errors related to ARM emulation, first ensure you've properly
+set up the prerequisites as described in the
 :doc:`Prerequisites section <prerequisites>`.
 
 Common error messages and their solutions:
-
-.. code-block:: text
-
-   update-binfmts: warning: Couldn't load the binfmt_misc module.
-
-OR
 
 .. code-block:: text
 
@@ -32,19 +26,26 @@ OR
 
 **Solution**:
 
-1. Verify these specific files exist on your system:
+The build script automatically registers QEMU emulation handlers when building
+on x86 systems. If you encounter the errors above:
+
+1. Ensure the required packages are installed:
 
    .. code-block:: bash
 
-      /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko
-      /usr/bin/qemu-arm-static
+      sudo apt-get install qemu-user-binfmt binfmt-support
 
-2. If necessary, install the missing packages and load the module:
+
+
+
+2. Make sure you're running the build script with ``sudo`` to allow Docker
+   privileged access for automatic QEMU registration.
+
+3. If the automatic registration fails, you can manually register QEMU handlers:
 
    .. code-block:: bash
 
-      sudo apt-get install qemu-user-static binfmt-support
-      sudo modprobe binfmt_misc
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 ----
 

--- a/stages/01.bootstrap/run.sh
+++ b/stages/01.bootstrap/run.sh
@@ -16,10 +16,6 @@ debootstrap --arch=${TARGET_ARCHITECTURE} \
 			--include=ca-certificates,curl,gnupg,wget \
 			--keyring "/usr/share/keyrings/debian-archive-"${DEBIAN_VERSION}"-stable.gpg" "${DEBIAN_VERSION}" "${BUILD_DIR}"
 
-if [[ "$(uname -m)" != "aarch64" && "$(uname -m)" != "arm*" ]]; then
-	cp /usr/bin/qemu-arm-static "${BUILD_DIR}"/usr/bin
-fi
-
 # Add adi-repo.list to sources.list
 install -m 644 "${BASH_SOURCE%%/run.sh}"/files/prefer-adi "${BUILD_DIR}/etc/apt/preferences.d/prefer-adi"
 install -m 644 "${BASH_SOURCE%%/run.sh}"/files/adi-libraries "${BUILD_DIR}/etc/apt/preferences.d/adi-libraries"


### PR DESCRIPTION
## Pull Request Description

Update the build process so that the emulation is managed by the host system instead of embedding emulator binaries inside the Kuiper image.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
