### PR TITLE
boot_partition: readme: Add versal apollo and fix formatting

### DIFF
--- a/stages/06.boot-partition/03.add-fstab/files/README.txt
+++ b/stages/06.boot-partition/03.add-fstab/files/README.txt
@@ -1,5 +1,8 @@
-INFO: If you are already booting the image on a hardware platfom, run 'sudo configure-setup.sh --help' and follow the steps for automatic preparation of the boot partition.
-Check this link for more informations: https://analogdevicesinc.github.io/kuiper/hardware-configuration.html
+INFO: If you are already booting the image on a hardware platfom, run 'sudo
+configure-setup.sh --help' and follow the steps for automatic preparation of
+the boot partition.
+Check this link for more information:
+    https://analogdevicesinc.github.io/kuiper/hardware-configuration.html
 If not, check the manual steps below:
 
 Platform-Specific Manual Steps
@@ -8,47 +11,57 @@ AMD/Xilinx Platforms
 
 For Zynq projects, copy these files to the root of the BOOT FAT32 partition:
     <target>/BOOT.BIN - First stage bootloader with FPGA bitstream
-    <target>/<specific_folder>/devicetree.dtb - Device tree for your specific project
+    <target>/<specific_folder>/devicetree.dtb - Device tree for your specific
+    project
     zynq-common/uImage - Kernel image for Zynq platforms
     zynq-common/uEnv.txt - U-Boot environment configuration
 
 For ZynqMP projects, copy these files to the root of the BOOT FAT32 partition:
     <target>/BOOT.BIN - First stage bootloader with FPGA bitstream
-    <target>/<specific_folder>/system.dtb - Device tree for your specific project
+    <target>/<specific_folder>/system.dtb - Device tree for your specific
+    project
     zynqmp-common/Image - Kernel image for ZynqMP platforms
     zynqmp-common/uEnv.txt - U-Boot environment configuration
 
 For Versal projects, copy these files to the root of the BOOT FAT32 partition:
     <target>/BOOT.BIN - Platform Loader and Manager (PLM) and boot components
-    <target>/<specific_folder>/system.dtb - Device tree for your specific project
+    <target>/<specific_folder>/system.dtb - Device tree for your specific
+    project
     <target>/boot.scr - U-Boot script for Versal boot sequence
     versal-common/Image - Kernel image for Versal platforms
     versal-common/uEnv.txt - U-Boot environment configuration
 
-For Versal-Apollo projects, copy these files to the root of the BOOT FAT32 partition::
-    versal_apollo/<target>/BOOT.BIN - Platform Loader and Manager (PLM) and boot components
-    versal_apollo/<target>/<specific_folder>/system.dtb - Device tree for your specific project
+For Versal-Apollo projects, copy these files to the root of the BOOT FAT32
+partition:
+    versal_apollo/<target>/BOOT.BIN - Platform Loader and Manager (PLM) and
+    boot components
+    versal_apollo/<target>/<specific_folder>/system.dtb - Device tree for your
+    specific project
     versal_apollo/<target>/boot.scr - U-Boot script for Versal boot sequence
     versal_apollo/Image - Kernel image for Versal-Apollo platforms
     versal-common/uEnv.txt - U-Boot environment configuration
 
 Intel/Altera Platforms
 
-For Arria10 SoC projects, copy these files to the root of the BOOT FAT32 partition:
+For Arria10 SoC projects, copy these files to the root of the BOOT FAT32
+partition:
     <target>/fit_spl_fpga.itb - FPGA configuration and SPL image
     <target>/socfpga_arria10_socdk_sdmmc.dtb - Device tree
     <target>/u-boot.img - U-Boot proper
     socfpga_arria10_common/zImage - Kernel image
-Create an extlinux folder in the boot partition and copy socfpga_arria10_common/extlinux.conf into it
+Create an extlinux folder in the boot partition and copy
+socfpga_arria10_common/extlinux.conf into it.
 Write the preloader (replace mmcblkXp3 with your actual device):
     'sudo dd if=<target>/u-boot-splx4.sfp of=/dev/mmcblk0p3 status=progress'
 
-For Cyclone5 projects, copy these files to the root of the BOOT FAT32 partition:
+For Cyclone5 projects, copy these files to the root of the BOOT FAT32
+partition:
     <target>/soc_system.rbf - FPGA bitstream
     <target>/socfpga.dtb - Device tree
     <target>/u-boot.scr - U-Boot script
     socfpga_cyclone5_common/zImage - Kernel image
-Create an extlinux folder in the boot partition and copy socfpga_cyclone5_common/extlinux.conf into it
+Create an extlinux folder in the boot partition and copy
+socfpga_cyclone5_common/extlinux.conf into it
 Write the preloader (replace mmcblkXp3 with your actual device):
     'sudo dd if=<target>/u-boot-with-spl.sfp of=/dev/mmcblk0p3 status=progress'
     
@@ -60,10 +73,12 @@ For loading RPI overlays the are 2 methods:
     "dtoverlay=<overlay_name>[,<overlay_arguments>]"
   - or you can load an overlay dinamically, after RPI booted, by opening a
     terminal and typing "sudo dtoverlay <overlay_name>[,<overlay_arguments>]"
-In both cases, there needs to be specified only the overlay name, without extension and path.
+In both cases, there needs to be specified only the overlay name, without
+extension and path.
 Overlays binaries (*.dtbo) can be found in /boot/overlays.
 
-INFO: After editing the config.txt file you need to reboot you device so that the changes are loaded.
+INFO: After editing the config.txt file you need to reboot you device so that
+the changes are loaded.
 
 Documentation:
     https://analogdevicesinc.github.io/kuiper/

--- a/stages/06.boot-partition/03.add-fstab/files/README.txt
+++ b/stages/06.boot-partition/03.add-fstab/files/README.txt
@@ -23,7 +23,14 @@ For Versal projects, copy these files to the root of the BOOT FAT32 partition:
     <target>/<specific_folder>/system.dtb - Device tree for your specific project
     <target>/boot.scr - U-Boot script for Versal boot sequence
     versal-common/Image - Kernel image for Versal platforms
+    versal-common/uEnv.txt - U-Boot environment configuration
 
+For Versal-Apollo projects, copy these files to the root of the BOOT FAT32 partition::
+    versal_apollo/<target>/BOOT.BIN - Platform Loader and Manager (PLM) and boot components
+    versal_apollo/<target>/<specific_folder>/system.dtb - Device tree for your specific project
+    versal_apollo/<target>/boot.scr - U-Boot script for Versal boot sequence
+    versal_apollo/Image - Kernel image for Versal-Apollo platforms
+    versal-common/uEnv.txt - U-Boot environment configuration
 
 Intel/Altera Platforms
 


### PR DESCRIPTION
## Pull Request Description

Update boot partition README to contain case for versal-apollo projects.
Fix formatting (to meet 80-characters standard) and small typo in README.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
