### PR TITLE
Add configurable hostname

### DIFF
--- a/config
+++ b/config
@@ -10,6 +10,9 @@ TARGET_ARCHITECTURE=armhf
 # Set the Debian version for Kuiper. Options: bullseye, bookworm, trixie.
 DEBIAN_VERSION=trixie
 #
+# Set the hostname for the system. Default: analog
+HOSTNAME=analog
+#
 # Preserve the Docker container.
 PRESERVE_CONTAINER=n
 #

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,6 +47,11 @@ These options control the fundamental aspects of your Kuiper image:
      - ``trixie``
      - Debian version to use (e.g., ``trixie``, ``bookworm``, ``bullseye``).
        Versions other than the default may have limited support
+   * - ``HOSTNAME``
+     - ``analog``
+     - System hostname. Useful for identifying devices on a network, especially
+       when running multiple boards. The hostname is used for SSH connections
+       and network discovery (e.g., ``analog.local`` via mDNS/Avahi)
 
 ----
 
@@ -352,3 +357,22 @@ Complete development environment with GNU Radio
    CONFIG_LIBM2K=y
    CONFIG_GNURADIO=y
    CONFIG_GRM2K=y
+
+Building images for multiple devices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When deploying multiple Kuiper boards on the same network, set unique hostnames
+to avoid conflicts:
+
+.. code-block:: bash
+   :caption: config file settings for first device
+
+   HOSTNAME=pluto-sdr-lab-01
+
+.. code-block:: bash
+   :caption: config file settings for second device
+
+   HOSTNAME=pluto-sdr-lab-02
+
+This allows you to connect to specific devices via SSH using their hostname
+(e.g., ``ssh analog@pluto-sdr-lab-01.local``)

--- a/docs/use-kuiper-image.rst
+++ b/docs/use-kuiper-image.rst
@@ -353,17 +353,25 @@ see device information.
 
 ----
 
-Change the hostname and MAC address
------------------------------------
+Customizing Hostname and MAC Address
+-------------------------------------
 
-By default, the hostname is ``analog`` for every Kuiper install. If you have
-multiple devices in the same network with the same hostname, mDNS/Avahi won't
-work properly. Set-up a new, unique hostname, with:
+Changing the Hostname
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the hostname is ``analog`` for every Kuiper image (unless customized
+at build time). If you have multiple devices on the same network with the same
+hostname, mDNS/Avahi won't work properly.
+
+To set a new, unique hostname:
 
 .. shell::
 
    $hostnamectl set-hostname analog-my-device
    $systemctl restart avahi-daemon
+
+Changing MAC Address
+~~~~~~~~~~~~~~~~~~~~~
 
 To persistently change the MAC address will depend on your carrier, you may be
 able through ``/boot/uEnv.txt`` by adding ``ethaddr=<new-mac-address>``, or

--- a/kuiper-stages.sh
+++ b/kuiper-stages.sh
@@ -21,6 +21,7 @@ export TARGET_ARCHITECTURE=${TARGET_ARCHITECTURE:-armhf}
 export BUILD_DIR=${TARGET_ARCHITECTURE}_rootfs
 export IMG_FILE="image_"$(date +%Y-%m-%d)"-ADI-Kuiper-Linux-$TARGET_ARCHITECTURE.img"
 export NUM_JOBS=${NUM_JOBS:-$(nproc)}
+export HOSTNAME=${HOSTNAME:-analog}
 
 export CONFIG_DESKTOP=${CONFIG_DESKTOP:-n}
 export CONFIG_LIBIIO=${CONFIG_LIBIIO:-n}

--- a/stages/03.system-tweaks/01.create-system-users/run.sh
+++ b/stages/03.system-tweaks/01.create-system-users/run.sh
@@ -23,9 +23,9 @@ chroot "${BUILD_DIR}" << EOF
 		adduser analog \$GRP
 	done
 
-	# Set the name of the machine to 'analog'
-	echo "analog" > /etc/hostname
-	echo "127.0.1.1 analog" >> /etc/hosts
+	# Set the hostname
+	echo "${HOSTNAME}" > /etc/hostname
+	echo "127.0.1.1 ${HOSTNAME}" >> /etc/hosts
 
 	# Set root PATH to all users for the desktop environment
 	echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' > /etc/environment


### PR DESCRIPTION
Hostname is now configurable by setting the HOSTNAME variable in the config file. This is useful for instances where multiple Kuiper devices are using the same network. Configurable hostnames make it easy to differentiate these devices.

Also update documentation accordingly.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes.
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR.
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] New feature (change that adds new functionality)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
