### PR TITLE
08.export-stage/01.extend-rootfs: Fix extend on boards with eMMC

### DIFF
--- a/stages/02.set-locale-and-timezone/03.mandatory-packages/00.install-packages/packages
+++ b/stages/02.set-locale-and-timezone/03.mandatory-packages/00.install-packages/packages
@@ -25,3 +25,4 @@ bash-completion
 jq
 bsdextrautils
 python3-pip
+cloud-guest-utils

--- a/stages/08.export-stage/01.extend-rootfs/files/extend-rootfs-once
+++ b/stages/08.export-stage/01.extend-rootfs/files/extend-rootfs-once
@@ -9,22 +9,10 @@
 # Description:
 ### END INIT INFO
 
-PART_START="$(parted /dev/mmcblk0 -ms unit s p | grep "^2" | cut -f 2 -d: | sed 's/[^0-9]*//g')"
-[ "$PART_START" ] || return 1
+ROOT_PART="$(readlink -f /dev/disk/by-label/rootfs)"
+DISK="/dev/$(lsblk -no pkname "$ROOT_PART")"
 
-fdisk /dev/mmcblk0 <<EOF
-p
-d
-2
-n
-p
-2
-$((PART_START))
-
-p
-w
-EOF
-
-sudo resize2fs /dev/mmcblk0p2 >/dev/null 2>&1
+sudo growpart "$DISK" 2
+sudo resize2fs "$ROOT_PART" >/dev/null 2>&1
 
 rm /etc/init.d/extend-rootfs-once


### PR DESCRIPTION
## Pull Request Description

02.set-locale-and-timezone/03.mandatory-packages/00.install-packages/packages: install a new package for extending rootfs 08.export-stage/01.extend-rootfs/files/extend-rootfs-once:
	- extract the DISK name instead of using mmcblk0 by default. This ensures that the rootfs will be correctly extended even if other devices are seen as mmcblkX.
	- update extend script to use growpart command instead of fdisk

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
