### PR TITLE
stages/03.system-tweaks/05.automount: fix automounting

### DIFF
--- a/stages/03.system-tweaks/05.automount/files/50-udisks.rules
+++ b/stages/03.system-tweaks/05.automount/files/50-udisks.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+ if (action.id.indexOf("org.freedesktop.udisks2.filesystem-mount") == 0 && subject.user == "analog") {
+  return polkit.Result.YES;
+ }
+});

--- a/stages/03.system-tweaks/05.automount/files/udiskie.service
+++ b/stages/03.system-tweaks/05.automount/files/udiskie.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=Udiskie service for managing removable media
-After=network.target graphical.target
+After=network.target
 
 [Service]
 # Start udiskie with the following parameters to make it independent of the desktop environment:
 # --no-notify: suppresses desktop notifications
 # -f "": prevents udiskie from managing any devices
+User=analog
+Group=analog
 ExecStart=/usr/bin/udiskie --no-notify -f ""
 Restart=on-failure
 


### PR DESCRIPTION
## Pull Request Description

Fix race conditions between services and add support for automounting on images without desktop login too.

stages/03.system-tweaks/05.automount/files/udiskie.service: remove condition to wait for graphical target (it creates loops and does not work for images without desktop env)
stages/03.system-tweaks/05.automount/files/50-udisks.rules: add rule to mount for user "analog"

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
