### PR TITLE
Add Debian snapshot pinning for reproducible builds

### DIFF
--- a/config
+++ b/config
@@ -10,6 +10,12 @@ TARGET_ARCHITECTURE=armhf
 # Set the Debian version for Kuiper. Options: bullseye, bookworm, trixie.
 DEBIAN_VERSION=trixie
 #
+# Pin the Debian base to a reproducible snapshot from snapshot.debian.org.
+# Leave empty to use the live mirror (deb.debian.org). Set to a timestamp
+# (format: YYYYMMDD) to freeze package versions
+# Note: only the Debian archive is pinned; the Raspberry Pi and ADI repos stay live
+DEBIAN_SNAPSHOT=20260701
+#
 # Set the hostname for the system. Default: analog
 HOSTNAME=analog
 #

--- a/kuiper-stages.sh
+++ b/kuiper-stages.sh
@@ -22,6 +22,7 @@ export BUILD_DIR=${TARGET_ARCHITECTURE}_rootfs
 export IMG_FILE="image_"$(date +%Y-%m-%d)"-ADI-Kuiper-Linux-$TARGET_ARCHITECTURE.img"
 export NUM_JOBS=${NUM_JOBS:-$(nproc)}
 export HOSTNAME=${HOSTNAME:-analog}
+export DEBIAN_SNAPSHOT=${DEBIAN_SNAPSHOT:-""}
 
 export CONFIG_DESKTOP=${CONFIG_DESKTOP:-n}
 export CONFIG_LIBIIO=${CONFIG_LIBIIO:-n}
@@ -76,6 +77,15 @@ export INSTALL_RPI_PACKAGES=${INSTALL_RPI_PACKAGES:-n}
 if [[ ! ${TARGET_ARCHITECTURE} = armhf && ! ${TARGET_ARCHITECTURE} = arm64 ]]; then
 	echo "Unsupported architecture ${TARGET_ARCHITECTURE}"
 	exit 1
+fi
+
+# Validate the snapshot timestamp
+if [ -n "${DEBIAN_SNAPSHOT}" ]; then
+	if [[ ! ${DEBIAN_SNAPSHOT} =~ ^[0-9]{8}(T[0-9]{6}Z)?$ ]]; then
+		echo "Invalid DEBIAN_SNAPSHOT '${DEBIAN_SNAPSHOT}'"
+		echo "Expected format YYYYMMDD or YYYYMMDDTHHMMSSZ, e.g. 20260615T000000Z"
+		exit 1
+	fi
 fi
 
 # Save logs with timestamps in build.log

--- a/stages/01.bootstrap/run.sh
+++ b/stages/01.bootstrap/run.sh
@@ -11,10 +11,27 @@ if [[ "$(uname -m)" != "aarch64" && "$(uname -m)" != "arm*" ]]; then
 fi
 
 mkdir "${BUILD_DIR}"
+
+# When DEBIAN_SNAPSHOT is set, pin the base to a reproducible snapshot from
+# snapshot.debian.org instead of the live mirror
+DEBOOTSTRAP_MIRROR=""
+if [ -n "${DEBIAN_SNAPSHOT}" ]; then
+	DEBOOTSTRAP_MIRROR="https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/"
+	echo "Installing from Debian snapshot ${DEBIAN_SNAPSHOT}"
+fi
+
 debootstrap --arch=${TARGET_ARCHITECTURE} \
 			--components "main,non-free,non-free-firmware" \
 			--include=ca-certificates,curl,gnupg,wget \
-			--keyring "/usr/share/keyrings/debian-archive-"${DEBIAN_VERSION}"-stable.gpg" "${DEBIAN_VERSION}" "${BUILD_DIR}"
+			--keyring "/usr/share/keyrings/debian-archive-"${DEBIAN_VERSION}"-stable.gpg" "${DEBIAN_VERSION}" "${BUILD_DIR}" ${DEBOOTSTRAP_MIRROR}
+
+# Point the chroot's apt sources at the same snapshot and disable the
+# Valid-Until check so dist-upgrade and later stages stay pinned too
+if [ -n "${DEBIAN_SNAPSHOT}" ]; then
+	sed -i -E "s|^(deb(-src)?) \S+|\1 ${DEBOOTSTRAP_MIRROR}|" \
+		"${BUILD_DIR}/etc/apt/sources.list"
+	echo 'Acquire::Check-Valid-Until "false";' > "${BUILD_DIR}/etc/apt/apt.conf.d/10no-check-valid-until"
+fi
 
 # Add adi-repo.list to sources.list
 install -m 644 "${BASH_SOURCE%%/run.sh}"/files/prefer-adi "${BUILD_DIR}/etc/apt/preferences.d/prefer-adi"

--- a/stages/08.export-stage/04.export-image/run.sh
+++ b/stages/08.export-stage/04.export-image/run.sh
@@ -6,6 +6,14 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # Author: Larisa Radu <larisa.radu@analog.com>
 
+# Restore the live Debian mirror so the device receives updates instead of being frozen to the snapshot
+if [ -n "${DEBIAN_SNAPSHOT}" ]; then
+	rm -f "${BUILD_DIR}/etc/apt/apt.conf.d/10no-check-valid-until"
+	DEBOOTSTRAP_MIRROR="https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/"
+	sed -i "s|${DEBOOTSTRAP_MIRROR}|http://deb.debian.org/debian|g" \
+		"${BUILD_DIR}/etc/apt/sources.list"
+fi
+
 EXPORT_ROOTFS_DIR="export_rootfs_dir"
 
 BOOTLOADER_SIZE="$((8 * 1024 * 1024))"


### PR DESCRIPTION
## Pull Request Description

Add a Debian snapshot option that pins Debian package repository to a fixed timestamp so every build installs the same package versions.

config: add DEBIAN_SNAPSHOT option with a default value
kuiper-stages.sh: export and validate DEBIAN_SNAPSHOT
stages/01.bootstrap/run.sh: pin the repository version
stages/08.export-stage/04.export-image/run.sh: restore the live mirror

This only pins the Debian packages from debian.org.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built Kuiper Linux image with the changes
- [x] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
