### PR TITLE
03.mandatory-packages/00.install-packages: gpiod

### DIFF
--- a/stages/02.set-locale-and-timezone/03.mandatory-packages/00.install-packages/packages
+++ b/stages/02.set-locale-and-timezone/03.mandatory-packages/00.install-packages/packages
@@ -26,3 +26,4 @@ jq
 bsdextrautils
 python3-pip
 cloud-guest-utils
+gpiod


### PR DESCRIPTION

## Pull Request Description

Add gpiod as a mandatory package since the gpio sysfs interface has been documented as deprecated since at least 2018:

https://github.com/torvalds/linux/commit/adbf02998b2e21e3f055f72fe2daa86260f03637

Install the gpiod package to enable users to interface using the 'new' ABI with utils such as gpioinfo, gpioget, gpioset.

Closes #263 

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
