### PR TITLE
docs/use-kuiper-image: add editors section

### DIFF
--- a/docs/hardware-configuration.rst
+++ b/docs/hardware-configuration.rst
@@ -514,7 +514,8 @@ overlays.
 Method 1: Persistent Configuration
 +++++++++++++++++++++++++++++++++++
 
-Edit ``/boot/config.txt`` to automatically load overlays on every boot.
+:ref:`Edit <editors>` ``/boot/config.txt`` to automatically load overlays on
+every boot.
 
 #. Open the configuration file and add a new line with your overlay:
 

--- a/docs/use-kuiper-image.rst
+++ b/docs/use-kuiper-image.rst
@@ -545,3 +545,21 @@ To persistently change the MAC address will depend on your carrier, you may be
 able through ``/boot/uEnv.txt`` by adding ``ethaddr=<new-mac-address>``, or
 through Linux through manipulating ``/etc/network/interfaces``. Check the
 carrier vendor documentation for full instructions.
+
+.. _editors:
+
+Using text editors
+------------------
+
+Kuiper images include the `nano <https://www.nano-editor.org/>`__ and
+`vim <https://www.vim.org/>`__ text editors by default.
+
+If you are new to command-line editors, these introductory guides may help:
+
+- nano: `Getting started with Nano - Red Hat <https://www.redhat.com/en/blog/getting-started-nano>`__
+- vim: `Linux basics: A beginner's guide to text editing with vim - Red Hat <https://www.redhat.com/en/blog/beginners-guide-vim>`__
+
+When using Kuiper with a display, you can also
+:ref:`install <package-management-kuiper>` a graphical editor, such as
+`gedit <https://gedit-text-editor.org/>`__, for a more familiar text editing
+experience.


### PR DESCRIPTION

## Pull Request Description

Based on human tests, users get suck at

  Hardware Configuration > Device Tree Overlays

Since it is the first step asking for in target file editing. Add a new section "Using Kuiper Images > Using text editors" that explain the pre-installed options, and provide easy to follow external tutorials.

closes #242

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
